### PR TITLE
Ingestor fix

### DIFF
--- a/src/lightcurvedb/__init__.py
+++ b/src/lightcurvedb/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.16.4"
+__version__ = "0.16.5"
 
 from lightcurvedb.core.connection import db, db_from_config
 

--- a/src/lightcurvedb/core/ingestors/frames.py
+++ b/src/lightcurvedb/core/ingestors/frames.py
@@ -106,7 +106,7 @@ def ingest_orbit(
         .join(Frame.orbit)
         .join(Frame.frame_type)
         .where(
-            Orbit.orbit_number == orbit_number,
+            Orbit.sector == orbit.sector,
             FrameType.name == frame_type.name,
         )
     )


### PR DESCRIPTION
Changing FFI ingestion pre-check to operate on sectors rather than orbits due to the nature of TICA delivery structure.