### PR TITLE
Update lightcurvedb for TGLC-updated light curves

### DIFF
--- a/src/lightcurvedb/core/ingestors/lightcurve_arrays.py
+++ b/src/lightcurvedb/core/ingestors/lightcurve_arrays.py
@@ -104,8 +104,38 @@ class BaseEM2ArrayIngestor(BufferedDatabaseIngestor):
         return id_
 
     def get_best_aperture_id(self, h5):
-        bestap = int(h5["LightCurve"]["AperturePhotometry"].attrs["bestap"])
-        name = f"Aperture_{bestap:03d}"  # noqa
+        aperture_photometry = h5["LightCurve"]["AperturePhotometry"]
+        if "PrimaryAperture" in aperture_photometry.keys():
+            name = aperture_photometry["PrimaryAperture"].attrs["name"]
+        else:
+            bestap = int(
+                h5["LightCurve"]["AperturePhotometry"].attrs["bestap"]
+            )
+            name = f"Aperture_{bestap:03d}"  # noqa
+        return self.get_aperture_id(name)
+
+    def get_small_aperture_id(self, h5):
+        aperture_photometry = h5["LightCurve"]["AperturePhotometry"]
+        if "SmallAperture" in aperture_photometry.keys():
+            name = aperture_photometry["SmallAperture"].attrs["name"]
+        else:
+            bestap = int(
+                h5["LightCurve"]["AperturePhotometry"].attrs["bestap"]
+            )
+            smallap = max(0, bestap - 1)
+            name = f"Aperture_{smallap:03d}"  # noqa
+        return self.get_aperture_id(name)
+
+    def get_large_aperture_id(self, h5):
+        aperture_photometry = h5["LightCurve"]["AperturePhotometry"]
+        if "LargeAperture" in aperture_photometry.keys():
+            name = aperture_photometry["LargeAperture"].attrs["name"]
+        else:
+            bestap = int(
+                h5["LightCurve"]["AperturePhotometry"].attrs["bestap"]
+            )
+            largeap = min(4, bestap + 1)
+            name = f"Aperture_{largeap:03d}"  # noqa
         return self.get_aperture_id(name)
 
     def get_lightcurve_type_id(self, name):
@@ -136,10 +166,14 @@ class BaseEM2ArrayIngestor(BufferedDatabaseIngestor):
                 )
             with self.record_elapsed("best-lightcurve-construction"):
                 best_aperture_id = self.get_best_aperture_id(h5)
+                small_aperture_id = self.get_small_aperture_id(h5)
+                large_aperture_id = self.get_large_aperture_id(h5)
                 best_type_id = self.get_best_lightcurve_type_id(h5)
                 best_lightcurve_definition = {
                     "orbit_id": self.orbit_map[em2_h5_job.orbit_number],
                     "aperture_id": best_aperture_id,
+                    "small_aperture_id": small_aperture_id,
+                    "large_aperture_id": large_aperture_id,
                     "lightcurve_type_id": best_type_id,
                     "tic_id": em2_h5_job.tic_id,
                 }

--- a/src/lightcurvedb/core/mixins.py
+++ b/src/lightcurvedb/core/mixins.py
@@ -44,13 +44,14 @@ class FrameAPIMixin(APIMixin):
     def get_mid_tjd_mapping(self, frame_type: typing.Union[str, None] = None):
         cameras = sa.select(m.Frame.camera.distinct())
 
-        tjd_q = (
-            sa.select(m.Frame.cadence, m.Frame.mid_tjd)
-            .order_by(m.Frame.cadence)
+        tjd_q = sa.select(m.Frame.cadence, m.Frame.mid_tjd).order_by(
+            m.Frame.cadence
         )
 
         if frame_type is not None:
-            tjd_q = tjd_q.join(m.Frame.frame_type).where(m.FrameType.name == frame_type)
+            tjd_q = tjd_q.join(m.Frame.frame_type).where(
+                m.FrameType.name == frame_type
+            )
 
         mapping = {}
         for (camera,) in self.execute(cameras):
@@ -116,7 +117,9 @@ class OrbitAPIMixin(APIMixin):
             )
         )
         if frame_type is not None:
-            q = q.join(m.Frame.frame_type).where(m.FrameType.name == frame_type)
+            q = q.join(m.Frame.frame_type).where(
+                m.FrameType.name == frame_type
+            )
         if ccd is not None:
             q = q.where(m.Frame.ccd == ccd)
         return self.execute(q).fetchone()
@@ -165,7 +168,9 @@ class OrbitAPIMixin(APIMixin):
             )
         )
         if frame_type is not None:
-            q = q.join(m.Frame.frame_type).where(m.FrameType.name == frame_type)
+            q = q.join(m.Frame.frame_type).where(
+                m.FrameType.name == frame_type
+            )
         if ccd is not None:
             q = q.where(m.Frame.ccd == ccd)
         return self.execute(q).fetchone()
@@ -341,8 +346,12 @@ class BestOrbitLightcurveAPIMixin(APIMixin):
         join_conditions = []
         filter_conditions = [LC.tic_id == tic_id]
 
-        if aperture is None:
+        if aperture is None or aperture == "primary":
             join_conditions.append(BEST_LC.aperture_id == LC.aperture_id)
+        elif aperture == "small":
+            join_conditions.append(BEST_LC.small_aperture_id == LC.aperture_id)
+        elif aperture == "large":
+            join_conditions.append(BEST_LC.large_aperture_id == LC.aperture_id)
         else:
             q = q.join(LC.aperture)
             filter_conditions.append(m.Aperture.name == aperture)
@@ -535,7 +544,9 @@ class LegacyAPIMixin(APIMixin):
             .order_by(m.Frame.cadence.asc())
         )
         if frame_type is not None:
-            q = q.join(m.Frame.frame_type).where(m.FrameType.name == frame_type)
+            q = q.join(m.Frame.frame_type).where(
+                m.FrameType.name == frame_type
+            )
         return self.execute(q).scalars().fetchall()
 
     def get_cadences_in_sectors(self, sectors, frame_type=None):
@@ -548,5 +559,7 @@ class LegacyAPIMixin(APIMixin):
             .order_by(m.Frame.cadence.asc())
         )
         if frame_type is not None:
-            q = q.join(m.Frame.frame_type).where(m.FrameType.name == frame_type)
+            q = q.join(m.Frame.frame_type).where(
+                m.FrameType.name == frame_type
+            )
         return self.execute(q).scalars().fetchall()

--- a/src/lightcurvedb/models/best_lightcurve.py
+++ b/src/lightcurvedb/models/best_lightcurve.py
@@ -27,6 +27,14 @@ class BestOrbitLightcurve(QLPModel, CreatedOnMixin):
         sa.ForeignKey("apertures.id", ondelete="RESTRICT"),
         index=True,
     )
+    small_aperture_id: Mapped[int] = mapped_column(
+        sa.ForeignKey("apertures.id", ondelete="RESTRICT"),
+        index=True,
+    )
+    large_aperture_id: Mapped[int] = mapped_column(
+        sa.ForeignKey("apertures.id", ondelete="RESTRICT"),
+        index=True,
+    )
     lightcurve_type_id: Mapped[int] = mapped_column(
         sa.ForeignKey("lightcurvetypes.id", ondelete="RESTRICT"),
         index=True,


### PR DESCRIPTION
## Overview

These updates modify `lightcurvedb` to be compatible with the new light curves that will be produced by TGLC ([QLP's version](https://github.com/mit-kavli-institute/tess-gaia-light-curve)). The updates cover the necessary logic in the light curve investor to identify aperture names and other photometry data as well as additions to the `BestOrbitLightcurve` model that specify small and large apertures (in addition to a "best"/primary aperture) for each star for each orbit.

The small and large aperture indicators were not necessary previously because the best/small/large apertures for each star were constant between orbits, but all three will change when TGLC is deployed. The best aperture is already included in `BestOrbitLightcurve`, and while in principle it is possible to determine the small and large apertures given the primary aperture, it is simpler and more flexible to specify them explicitly (and does not take much additional data).

Copied from the corresponding [QLP merge request on GitLab](https://tessgit.mit.edu/tess/FFITools/-/merge_requests/246), this is the new H5 light curve format.
```
LightCurve
  AperturePhotometry
    (meta):
      primarydetrending: "QSP"
    PrimaryAperture
      (meta):
        name: "TGLCAperturePrimary"
        description: "3x3 square aperture"
        local_background_magnitude: float
        psf_portion: float in [0, 1]
      RawMagnitude
      RawMagnitudeError
      QSPMagnitude
      QSPMagnitudeError
      QSPIntermediateMagnitude
      X
      Y
    SmallAperture
      (meta):
        name: "TGLCApertureSmall"
        description: "1x1 square aperture"
    LargeAperture
      name: "TGLCApertureLarge"
      description: "5x5 square aperture"
      ...
```

## Remaining Tasks
- [ ] The `star_radius`, `inner_radius`, and `outer_radius` columns on the `apertures` table need to be nullable since we are using simple square apertures for the TGLC apertures. I'm not sure what it would take to make this happen, either in terms of code changes or database migration, so maybe @WilliamCFong can help. If these columns aren't referred to elsewhere (I don't think they are anywhere in QLP), we could alternatively remove them and put the information into the QLP aperture descriptions.

## Database Preparation
- We will need to add `aperture` table entries for the three TGLC apertures. These will have null `*_radius` columns, and these names and descriptions:
  
  | Name                | Description                              |
  |---------------------|------------------------------------------|
  | TGLCAperturePrimary | 3x3 square aperture with TGLC photometry |
  | TGLCApertureSmall.  | 1x1 square aperture with TGLC photometry |
  | TGLCApertureLarge   | 5x5 square aperture with TGLC photometry |
- We will need to back populate the `BestOrbitLightcurve.small_aperture_id` and `BestOrbitLightcurve.large_aperture_id`. Based on the current state of the database, this should be the mapping (hopefully the background aperture is not actually anywhere in the `best_orbit_lightcurves` table, but it can map to itself for completeness).
  
  | id | Name               | small_id | large_id |
  |----|--------------------|----------|----------|
  | 1  | Aperture_000       | 1        | 2        |
  | 2  | Aperture_001       | 1        | 3        |
  | 3  | Aperture_002       | 2        | 4        |
  | 4  | Aperture_003       | 3        | 5        |
  | 5  | Aperture_004       | 4        | 5        |
  | 6  | BackgroundAperture | 6        | 6        |