### PR TITLE
Quality flag introduction

### DIFF
--- a/docs/source/db/db.rst
+++ b/docs/source/db/db.rst
@@ -4,5 +4,6 @@ DB Interface
 .. autofunction:: lightcurvedb.core.connection.db_from_config
 
 .. autofunction:: lightcurvedb.core.connection.configure_engine
+   :no-index:
 
 .. autodata:: lightcurvedb.core.connection.LCDB_Session

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -50,6 +50,13 @@ Observation Models
    :members:
    :show-inheritance:
 
+Quality Flag Models
+-------------------
+
+.. autoclass:: lightcurvedb.models.QualityFlagArray
+   :members:
+   :show-inheritance:
+
 Target Models
 -------------
 

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -56,6 +56,7 @@ Quality Flag Models
 .. autoclass:: lightcurvedb.models.QualityFlagArray
    :members:
    :show-inheritance:
+   :exclude-members: created_on
 
 Target Models
 -------------

--- a/src/lightcurvedb/core/base_model.py
+++ b/src/lightcurvedb/core/base_model.py
@@ -20,6 +20,7 @@ class LCDBModel(orm.DeclarativeBase):
         dict[str, Any]: JSONB,
         Decimal: sa.DOUBLE_PRECISION,
         npt.NDArray[np.int64]: sa.ARRAY(sa.BigInteger),
+        npt.NDArray[np.int32]: sa.ARRAY(sa.Integer),
         npt.NDArray[np.float64]: sa.ARRAY(sa.Float),
         pathlib.Path: sa.String,
     }

--- a/src/lightcurvedb/models/__init__.py
+++ b/src/lightcurvedb/models/__init__.py
@@ -7,6 +7,7 @@ from .dataset import (
 from .frame import FITSFrame
 from .instrument import Instrument
 from .observation import Observation, TargetSpecificTime
+from .quality_flag import QualityFlagArray
 from .target import Mission, MissionCatalog, Target
 
 __all__ = [
@@ -21,6 +22,7 @@ __all__ = [
     "Target",
     "TargetSpecificTime",
     "DataSet",
+    "QualityFlagArray",
 ]
 
 DEFINED_MODELS = __all__

--- a/src/lightcurvedb/models/observation.py
+++ b/src/lightcurvedb/models/observation.py
@@ -88,7 +88,12 @@ class Observation(LCDBModel):
     ] = orm.relationship(back_populates="observation")
     quality_flag_arrays: orm.Mapped[
         list["QualityFlagArray"]
-    ] = orm.relationship("QualityFlagArray", back_populates="observation")
+    ] = orm.relationship(
+        "QualityFlagArray",
+        back_populates="observation",
+        cascade="all, delete-orphan",
+        passive_deletes=True,
+    )
 
 
 class TargetSpecificTime(LCDBModel):

--- a/src/lightcurvedb/models/observation.py
+++ b/src/lightcurvedb/models/observation.py
@@ -11,6 +11,7 @@ from lightcurvedb.core.base_model import LCDBModel
 if TYPE_CHECKING:
     from lightcurvedb.models.dataset import DataSet
     from lightcurvedb.models.instrument import Instrument
+    from lightcurvedb.models.quality_flag import QualityFlagArray
     from lightcurvedb.models.target import Target
 
 
@@ -85,6 +86,9 @@ class Observation(LCDBModel):
     target_specific_times: orm.Mapped[
         list["TargetSpecificTime"]
     ] = orm.relationship(back_populates="observation")
+    quality_flag_arrays: orm.Mapped[
+        list["QualityFlagArray"]
+    ] = orm.relationship("QualityFlagArray", back_populates="observation")
 
 
 class TargetSpecificTime(LCDBModel):

--- a/src/lightcurvedb/models/quality_flag.py
+++ b/src/lightcurvedb/models/quality_flag.py
@@ -1,0 +1,38 @@
+from typing import TYPE_CHECKING
+
+import numpy as np
+import sqlalchemy as sa
+from numpy import typing as npt
+from sqlalchemy import orm
+
+from lightcurvedb.core.base_model import CreatedOnMixin, LCDBModel
+
+if TYPE_CHECKING:
+    from lightcurvedb.models.observation import Observation
+
+
+class QualityFlagArray(LCDBModel, CreatedOnMixin):
+
+    __tablename__ = "quality_flag_array"
+    __table_args__ = sa.UniqueConstraint(
+        "type", "observation_id", "target_id", name="distinct_quality_flags"
+    )
+    __mapper_args__ = {
+        "polymorphic_identity": "base_quality_flag",
+        "polymorphic_on": "type",
+    }
+
+    id: orm.Mapped[int] = orm.mapped_column(sa.BigInteger, primary_key=True)
+    type: orm.Mapped[str] = orm.mapped_column(index=True)
+    observation_id: orm.Mapped[int] = orm.mapped_column(
+        sa.ForeignKey("observation.id"), index=True
+    )
+    target_id: orm.Mapped[int] = orm.mapped_column(
+        sa.ForeignKey("target.id"), index=True, nullable=True
+    )
+
+    quality_flags: orm.Mapped[npt.NDArray[np.int32]]
+
+    observation: orm.Mapped["Observation"] = orm.relationship(
+        "Observation", back_populates="quality_flag_arrays"
+    )

--- a/src/lightcurvedb/models/quality_flag.py
+++ b/src/lightcurvedb/models/quality_flag.py
@@ -9,30 +9,127 @@ from lightcurvedb.core.base_model import CreatedOnMixin, LCDBModel
 
 if TYPE_CHECKING:
     from lightcurvedb.models.observation import Observation
+    from lightcurvedb.models.target import Target
 
 
 class QualityFlagArray(LCDBModel, CreatedOnMixin):
+    """
+    Stores quality flag arrays for astronomical observations.
+
+    QualityFlagArray represents bit-encoded quality information for
+    time-series astronomical data. Each element in the array corresponds
+    to a cadence in the observation, with individual bits representing
+    different quality conditions or data issues.
+
+    This is a polymorphic base class that can be extended for
+    mission-specific quality flag implementations with specialized
+    bit definitions.
+
+    Parameters
+    ----------
+    type : str
+        Quality flag type identifier (e.g., 'pixel_quality', 'cosmic_ray')
+    observation_id : int
+        Foreign key to the parent observation
+    target_id : int, optional
+        Foreign key to a specific target when flags are target-specific
+    quality_flags : ndarray[int32]
+        Array of 32-bit integers where each bit represents a quality condition
+
+    Attributes
+    ----------
+    id : int
+        Primary key identifier
+    type : str
+        Polymorphic discriminator and quality flag category
+    observation_id : int
+        Reference to the parent observation
+    target_id : int or None
+        Reference to specific target (null for observation-wide flags)
+    quality_flags : ndarray[int32]
+        Bit-encoded quality flag array
+    observation : Observation
+        Parent observation relationship
+    target : Target or None
+        Target relationship when flags are target-specific
+    created_on : datetime
+        Timestamp of record creation (from CreatedOnMixin)
+
+    Examples
+    --------
+    Creating observation-wide quality flags:
+
+    >>> obs_flags = QualityFlagArray(
+    ...     observation_id=12345,
+    ...     quality_flags=np.array([0, 1, 4, 5], dtype=np.int32)
+    ... )
+
+    Creating target-specific quality flags:
+
+    >>> target_flags = QualityFlagArray(
+    ...     observation_id=12345,
+    ...     target_id=67890,
+    ...     quality_flags=np.array([0, 0, 2, 8], dtype=np.int32)
+    ... )
+
+    Interpreting bit flags:
+
+    >>> # Bit 0: Cosmic ray
+    >>> # Bit 1: Saturation
+    >>> # Bit 2: Bad pixel
+    >>> cosmic_ray_mask = (flags.quality_flags & 1) != 0
+    >>> saturated_mask = (flags.quality_flags & 2) != 0
+
+    Notes
+    -----
+    The combination of (type, observation_id, target_id) must be unique,
+    preventing duplicate quality flag arrays for the same context.
+
+    Quality flag bit definitions are mission and type-specific. Subclasses
+    should document their specific bit meanings and may add helper methods
+    for flag interpretation.
+
+    See Also
+    --------
+    Observation : Parent observation model
+    Target : Associated target for target-specific flags
+    """
 
     __tablename__ = "quality_flag_array"
-    __table_args__ = sa.UniqueConstraint(
-        "type", "observation_id", "target_id", name="distinct_quality_flags"
+    __table_args__ = (
+        sa.UniqueConstraint(
+            "type",
+            "observation_id",
+            "target_id",
+            name="distinct_quality_flags",
+        ),
     )
     __mapper_args__ = {
         "polymorphic_identity": "base_quality_flag",
         "polymorphic_on": "type",
     }
 
+    # Primary key - uses BigInteger for large datasets
     id: orm.Mapped[int] = orm.mapped_column(sa.BigInteger, primary_key=True)
     type: orm.Mapped[str] = orm.mapped_column(index=True)
+
+    # Foreign key to parent observation - cascades on delete
     observation_id: orm.Mapped[int] = orm.mapped_column(
-        sa.ForeignKey("observation.id"), index=True
+        sa.ForeignKey("observation.id", ondelete="CASCADE"), index=True
     )
+
+    # Optional foreign key to specific target - null for observation-wide flags
     target_id: orm.Mapped[int] = orm.mapped_column(
         sa.ForeignKey("target.id"), index=True, nullable=True
     )
 
+    # Array of 32-bit integers where each bit represents a quality condition
+    # Length should match the observation's cadence array length
     quality_flags: orm.Mapped[npt.NDArray[np.int32]]
 
     observation: orm.Mapped["Observation"] = orm.relationship(
         "Observation", back_populates="quality_flag_arrays"
+    )
+    target: orm.Mapped["Target | None"] = orm.relationship(
+        "Target", back_populates="quality_flag_arrays"
     )

--- a/src/lightcurvedb/models/quality_flag.py
+++ b/src/lightcurvedb/models/quality_flag.py
@@ -80,10 +80,130 @@ class QualityFlagArray(LCDBModel, CreatedOnMixin):
     >>> cosmic_ray_mask = (flags.quality_flags & 1) != 0
     >>> saturated_mask = (flags.quality_flags & 2) != 0
 
+    Extending with single-table inheritance (simple approach):
+
+    >>> class TESSQualityFlags(QualityFlagArray):
+    ...     \"\"\"TESS-specific quality flags with known bit definitions.\"\"\"
+    ...     __mapper_args__ = {
+    ...         "polymorphic_identity": "tess_quality",
+    ...     }
+    ...     @property
+    ...     def cosmic_ray_events(self):
+    ...         \"\"\"Return mask of cosmic ray events (bit 0).\"\"\"
+    ...         flags = np.array(self.quality_flags, dtype=np.int32)
+    ...         return (flags & 1) != 0
+    ...     @property
+    ...     def saturated_pixels(self):
+    ...         \"\"\"Return mask of saturated pixels (bit 1).\"\"\"
+    ...         flags = np.array(self.quality_flags, dtype=np.int32)
+    ...         return (flags & 2) != 0
+    ...     @property
+    ...     def spacecraft_anomaly(self):
+    ...         \"\"\"Return mask of spacecraft anomalies (bit 4).\"\"\"
+    ...         flags = np.array(self.quality_flags, dtype=np.int32)
+    ...         return (flags & 16) != 0
+
+    Extending with joined-table inheritance (advanced approach)::
+
+        class SpectroscopicQualityFlags(QualityFlagArray):
+            \"\"\"Quality flags for spectroscopic observations.\"\"\"
+
+            __tablename__ = "spectroscopic_quality_flags"
+            __mapper_args__ = {
+                "polymorphic_identity": "spectroscopic_quality",
+            }
+
+            # Primary key also serves as foreign key to parent table
+            id = orm.mapped_column(
+                sa.ForeignKey("quality_flag_array.id"), primary_key=True
+            )
+
+            # Additional columns specific to spectroscopic data
+            wavelength_calibration_quality = orm.mapped_column(
+                sa.types.Float,
+                comment="Wavelength calibration quality score (0-1)"
+            )
+            spectral_resolution = orm.mapped_column(
+                sa.types.Float,
+                comment="Actual spectral resolution achieved"
+            )
+            calibration_lamp_id = orm.mapped_column(
+                sa.ForeignKey("calibration_lamp.id"), nullable=True
+            )
+
+            @property
+            def wavelength_drift(self):
+                \"\"\"Return mask of wavelength drift (bit 8).\"\"\"
+                flags = np.array(self.quality_flags, dtype=np.int32)
+                return (flags & 256) != 0
+
+        class PhotometricQualityFlags(QualityFlagArray):
+            \"\"\"Quality flags for photometric observations.\"\"\"
+
+            __tablename__ = "photometric_quality_flags"
+            __mapper_args__ = {
+                "polymorphic_identity": "photometric_quality",
+            }
+
+            id = orm.mapped_column(
+                sa.ForeignKey("quality_flag_array.id"), primary_key=True
+            )
+
+            # Photometry-specific metadata
+            sky_background_level = orm.mapped_column(
+                sa.types.Float,
+                comment="Median sky background in counts"
+            )
+            fwhm = orm.mapped_column(
+                sa.types.Float,
+                comment="Full width at half maximum of PSF"
+            )
+            extinction_coefficient = orm.mapped_column(
+                sa.types.Float, nullable=True
+            )
+
+    Polymorphic querying examples:
+
+    >>> # Query all quality flags for an observation
+    >>> all_flags = session.query(QualityFlagArray).filter_by(
+    ...     observation_id=12345
+    ... ).all()
+
+    >>> # Query only TESS quality flags
+    >>> tess_flags = session.query(TESSQualityFlags).filter_by(
+    ...     observation_id=12345
+    ... ).all()
+
+    >>> # Use with_polymorphic for efficient joined loading
+    >>> from sqlalchemy.orm import with_polymorphic
+    >>>
+    >>> poly_flags = with_polymorphic(
+    ...     QualityFlagArray,
+    ...     [SpectroscopicQualityFlags, PhotometricQualityFlags]
+    ... )
+    >>> query = session.query(poly_flags).filter(
+    ...     poly_flags.observation_id == 12345
+    ... )
+    >>>
+    >>> # Access subclass-specific attributes without additional queries
+    >>> for flag in query:
+    ...     if isinstance(flag, SpectroscopicQualityFlags):
+    ...         print(f"Spectral resolution: {flag.spectral_resolution}")
+    ...     elif isinstance(flag, PhotometricQualityFlags):
+    ...         print(f"Sky background: {flag.sky_background_level}")
+
+    >>> # Filter by polymorphic type
+    >>> spectro_only = session.query(QualityFlagArray).filter_by(
+    ...     type="spectroscopic_quality"
+    ... ).all()
+
     Notes
     -----
     The combination of (type, observation_id, target_id) must be unique,
-    preventing duplicate quality flag arrays for the same context.
+    preventing duplicate quality flag arrays for the same context. NULL
+    values in target_id are treated as equal, so only one observation-wide
+    quality flag array (with NULL target_id) is allowed per type and
+    observation_id combination.
 
     Quality flag bit definitions are mission and type-specific. Subclasses
     should document their specific bit meanings and may add helper methods
@@ -96,14 +216,6 @@ class QualityFlagArray(LCDBModel, CreatedOnMixin):
     """
 
     __tablename__ = "quality_flag_array"
-    __table_args__ = (
-        sa.UniqueConstraint(
-            "type",
-            "observation_id",
-            "target_id",
-            name="distinct_quality_flags",
-        ),
-    )
     __mapper_args__ = {
         "polymorphic_identity": "base_quality_flag",
         "polymorphic_on": "type",
@@ -133,3 +245,16 @@ class QualityFlagArray(LCDBModel, CreatedOnMixin):
     target: orm.Mapped["Target | None"] = orm.relationship(
         "Target", back_populates="quality_flag_arrays"
     )
+
+
+# Create unique index that treats NULL target_id values as equal
+# This ensures only one quality flag array per (type, observation_id,
+# target_id) combination. Using COALESCE with -1 as sentinel value for
+# NULL target_id to enforce uniqueness
+sa.Index(
+    "distinct_quality_flags",
+    QualityFlagArray.type,
+    QualityFlagArray.observation_id,
+    sa.func.coalesce(QualityFlagArray.target_id, -1),
+    unique=True,
+)

--- a/src/lightcurvedb/models/target.py
+++ b/src/lightcurvedb/models/target.py
@@ -14,6 +14,7 @@ from lightcurvedb.core.base_model import LCDBModel
 if TYPE_CHECKING:
     from lightcurvedb.models.dataset import DataSet
     from lightcurvedb.models.observation import TargetSpecificTime
+    from lightcurvedb.models.quality_flag import QualityFlagArray
 
 
 class Mission(LCDBModel):
@@ -143,6 +144,8 @@ class Target(LCDBModel):
         Processed lightcurve datasets for this target
     target_specific_times : list[TargetSpecificTime]
         Time series specific to this target
+    quality_flag_arrays : list[QualityFlagArray]
+        Target-specific quality flags
 
     Notes
     -----
@@ -168,4 +171,7 @@ class Target(LCDBModel):
     )
     target_specific_times: orm.Mapped[
         list["TargetSpecificTime"]
+    ] = orm.relationship(back_populates="target")
+    quality_flag_arrays: orm.Mapped[
+        list["QualityFlagArray"]
     ] = orm.relationship(back_populates="target")

--- a/tests/test_quality_flag.py
+++ b/tests/test_quality_flag.py
@@ -1,0 +1,476 @@
+"""Test QualityFlagArray model functionality."""
+
+import uuid
+
+import numpy as np
+import pytest
+from sqlalchemy import exc, orm
+
+from lightcurvedb.models import (
+    Instrument,
+    Mission,
+    MissionCatalog,
+    Observation,
+    QualityFlagArray,
+    Target,
+)
+
+
+class TestQualityFlagArrayBasics:
+    """Test basic QualityFlagArray model functionality."""
+
+    def test_create_observation_wide_quality_flags(self, v2_db: orm.Session):
+        """Test creating quality flags for an entire observation."""
+        # Create required dependencies
+        mission = Mission(
+            id=uuid.uuid4(),
+            name="TEST_MISSION",
+            description="Test Mission",
+            time_unit="day",
+            time_epoch=0.0,
+            time_epoch_scale="tdb",
+            time_epoch_format="jd",
+            time_format_name="test_time",
+        )
+        instrument = Instrument(name="Test Instrument", properties={})
+        observation = Observation(
+            cadence_reference=np.array([1, 2, 3, 4]),
+            instrument=instrument,
+        )
+        v2_db.add_all([mission, instrument, observation])
+        v2_db.flush()
+
+        # Create observation-wide quality flags
+        quality_flags = QualityFlagArray(
+            observation_id=observation.id,
+            quality_flags=np.array([0, 1, 4, 5], dtype=np.int32),
+        )
+        v2_db.add(quality_flags)
+        v2_db.commit()
+
+        # Verify creation
+        assert quality_flags.id is not None
+        assert quality_flags.observation_id == observation.id
+        assert quality_flags.target_id is None
+        assert np.array_equal(
+            quality_flags.quality_flags, np.array([0, 1, 4, 5])
+        )
+        assert quality_flags.created_on is not None
+
+    def test_create_target_specific_quality_flags(self, v2_db: orm.Session):
+        """Test creating quality flags specific to a target."""
+        # Create required dependencies
+        mission = Mission(
+            id=uuid.uuid4(),
+            name="TEST_MISSION_2",
+            description="Test Mission 2",
+            time_unit="day",
+            time_epoch=0.0,
+            time_epoch_scale="tdb",
+            time_epoch_format="jd",
+            time_format_name="test_time_2",
+        )
+        catalog = MissionCatalog(
+            name="TEST_CATALOG",
+            description="Test Catalog",
+            host_mission=mission,
+        )
+        target = Target(name=12345678, catalog=catalog)
+        instrument = Instrument(name="Test Instrument 2", properties={})
+        observation = Observation(
+            cadence_reference=np.array([1, 2, 3, 4]),
+            instrument=instrument,
+        )
+        v2_db.add_all([mission, catalog, target, instrument, observation])
+        v2_db.flush()
+
+        # Create target-specific quality flags
+        quality_flags = QualityFlagArray(
+            observation_id=observation.id,
+            target_id=target.id,
+            quality_flags=np.array([0, 0, 2, 8], dtype=np.int32),
+        )
+        v2_db.add(quality_flags)
+        v2_db.commit()
+
+        # Verify creation
+        assert quality_flags.target_id == target.id
+
+    def test_quality_flag_array_length_matches_cadence(
+        self, v2_db: orm.Session
+    ):
+        """Test that quality flag array can match observation cadence."""
+        # Create observation with specific cadence length
+        instrument = Instrument(name="Test Instrument 3", properties={})
+        cadence_array = np.arange(100)
+        observation = Observation(
+            cadence_reference=cadence_array,
+            instrument=instrument,
+        )
+        v2_db.add_all([instrument, observation])
+        v2_db.flush()
+
+        # Create quality flags matching cadence length
+        quality_array = np.zeros(100, dtype=np.int32)
+        quality_flags = QualityFlagArray(
+            observation_id=observation.id,
+            quality_flags=quality_array,
+        )
+        v2_db.add(quality_flags)
+        v2_db.commit()
+
+        assert len(quality_flags.quality_flags) == len(
+            observation.cadence_reference
+        )
+
+
+class TestQualityFlagArrayRelationships:
+    """Test QualityFlagArray relationships."""
+
+    def test_observation_relationship(self, v2_db: orm.Session):
+        """Test bidirectional relationship with Observation."""
+        instrument = Instrument(name="Test Instrument 4", properties={})
+        observation = Observation(
+            type="observation",  # Use base polymorphic identity
+            cadence_reference=np.array([1, 2, 3]),
+            instrument=instrument,
+        )
+        v2_db.add_all([instrument, observation])
+        v2_db.flush()
+
+        # Create quality flag for the observation
+        quality_flags = QualityFlagArray(
+            observation=observation,
+            quality_flags=np.array([0, 1, 0], dtype=np.int32),
+        )
+        v2_db.add(quality_flags)
+        v2_db.commit()
+
+        # Test observation -> quality_flag_arrays relationship
+        assert len(observation.quality_flag_arrays) == 1
+        assert quality_flags in observation.quality_flag_arrays
+
+        # Test quality_flag_array -> observation relationship
+        assert quality_flags.observation == observation
+
+    def test_target_relationship(self, v2_db: orm.Session):
+        """Test bidirectional relationship with Target."""
+        mission = Mission(
+            id=uuid.uuid4(),
+            name="TEST_MISSION_3",
+            description="Test Mission 3",
+            time_unit="day",
+            time_epoch=0.0,
+            time_epoch_scale="tdb",
+            time_epoch_format="jd",
+            time_format_name="test_time_3",
+        )
+        catalog = MissionCatalog(
+            name="TEST_CATALOG_2",
+            description="Test Catalog 2",
+            host_mission=mission,
+        )
+        target = Target(name=87654321, catalog=catalog)
+        instrument = Instrument(name="Test Instrument 5", properties={})
+        observation = Observation(
+            type="observation",  # Use base polymorphic identity
+            cadence_reference=np.array([1, 2, 3]),
+            instrument=instrument,
+        )
+        v2_db.add_all([mission, catalog, target, instrument, observation])
+        v2_db.flush()
+
+        # Create target-specific quality flags
+        target_flags = QualityFlagArray(
+            observation=observation,
+            target=target,
+            quality_flags=np.array([1, 1, 1], dtype=np.int32),
+        )
+        v2_db.add(target_flags)
+        v2_db.commit()
+
+        # Test target -> quality_flag_arrays relationship
+        assert len(target.quality_flag_arrays) == 1
+        assert target_flags in target.quality_flag_arrays
+
+        # Test quality_flag_array -> target relationship
+        assert target_flags.target == target
+
+
+class TestQualityFlagArrayConstraints:
+    """Test QualityFlagArray database constraints."""
+
+    def test_unique_constraint(self, v2_db: orm.Session):
+        """Test unique constraint on (type, observation_id, target_id)."""
+        instrument = Instrument(name="Test Instrument 6", properties={})
+        observation = Observation(
+            cadence_reference=np.array([1, 2]),
+            instrument=instrument,
+        )
+        v2_db.add_all([instrument, observation])
+        v2_db.flush()
+
+        # Create first quality flag
+        flags1 = QualityFlagArray(
+            observation_id=observation.id,
+            quality_flags=np.array([0, 1], dtype=np.int32),
+        )
+        v2_db.add(flags1)
+        v2_db.commit()
+
+        # Try to create duplicate with same type (base_quality_flag)
+        flags2 = QualityFlagArray(
+            observation_id=observation.id,  # Same observation
+            quality_flags=np.array([1, 0], dtype=np.int32),
+        )
+        v2_db.add(flags2)
+
+        # The type should also default to base_quality_flag
+        with pytest.raises(exc.IntegrityError):
+            v2_db.flush()
+        v2_db.rollback()
+
+    def test_cascade_delete_from_observation(self, v2_db: orm.Session):
+        """Test quality flags are deleted when observation is deleted."""
+        instrument = Instrument(name="Test Instrument 7", properties={})
+        observation = Observation(
+            cadence_reference=np.array([1, 2]),
+            instrument=instrument,
+        )
+        v2_db.add_all([instrument, observation])
+        v2_db.flush()
+
+        quality_flags = QualityFlagArray(
+            observation=observation,
+            quality_flags=np.array([0, 1], dtype=np.int32),
+        )
+        v2_db.add(quality_flags)
+        v2_db.commit()
+
+        flag_id = quality_flags.id
+
+        # Verify flag exists
+        assert (
+            v2_db.query(QualityFlagArray).filter_by(id=flag_id).first()
+            is not None
+        )
+
+        # Delete observation
+        v2_db.delete(observation)
+        v2_db.commit()
+
+        # Verify quality flags were deleted (cascade worked)
+        assert (
+            v2_db.query(QualityFlagArray).filter_by(id=flag_id).first() is None
+        )
+
+    def test_foreign_key_constraint_observation(self, v2_db: orm.Session):
+        """Test foreign key constraint for invalid observation_id."""
+        quality_flags = QualityFlagArray(
+            observation_id=999999,  # Non-existent observation
+            quality_flags=np.array([0, 1], dtype=np.int32),
+        )
+        v2_db.add(quality_flags)
+
+        with pytest.raises(exc.IntegrityError):
+            v2_db.commit()
+        v2_db.rollback()
+
+    def test_foreign_key_constraint_target(self, v2_db: orm.Session):
+        """Test foreign key constraint for invalid target_id."""
+        instrument = Instrument(name="Test Instrument 8", properties={})
+        observation = Observation(
+            cadence_reference=np.array([1, 2]),
+            instrument=instrument,
+        )
+        v2_db.add_all([instrument, observation])
+        v2_db.flush()
+
+        quality_flags = QualityFlagArray(
+            observation_id=observation.id,
+            target_id=999999,  # Non-existent target
+            quality_flags=np.array([0, 1], dtype=np.int32),
+        )
+        v2_db.add(quality_flags)
+
+        with pytest.raises(exc.IntegrityError):
+            v2_db.commit()
+        v2_db.rollback()
+
+
+class TestQualityFlagArrayBitOperations:
+    """Test bit manipulation operations on quality flags."""
+
+    def test_bit_flag_interpretation(self, v2_db: orm.Session):
+        """Test interpreting individual bits in quality flags."""
+        instrument = Instrument(name="Test Instrument 9", properties={})
+        observation = Observation(
+            cadence_reference=np.array([1, 2, 3, 4]),
+            instrument=instrument,
+        )
+        v2_db.add_all([instrument, observation])
+        v2_db.flush()
+
+        # Create flags with specific bit patterns
+        # Bit 0: Cosmic ray (1)
+        # Bit 1: Saturation (2)
+        # Bit 2: Bad pixel (4)
+        quality_flags = QualityFlagArray(
+            observation=observation,
+            quality_flags=np.array(
+                [0, 1, 2, 7], dtype=np.int32
+            ),  # 0, cosmic ray, saturation, all three
+        )
+        v2_db.add(quality_flags)
+        v2_db.commit()
+
+        # Test bit interpretation
+        v2_db.refresh(quality_flags)  # Refresh to ensure data is loaded
+        flags = np.array(
+            quality_flags.quality_flags, dtype=np.int32
+        )  # Ensure numpy array
+
+        # Check cosmic ray bit (bit 0)
+        cosmic_ray_mask = (flags & 1) != 0
+        assert np.array_equal(cosmic_ray_mask, [False, True, False, True])
+
+        # Check saturation bit (bit 1)
+        saturation_mask = (flags & 2) != 0
+        assert np.array_equal(saturation_mask, [False, False, True, True])
+
+        # Check bad pixel bit (bit 2)
+        bad_pixel_mask = (flags & 4) != 0
+        assert np.array_equal(bad_pixel_mask, [False, False, False, True])
+
+    def test_maximum_bit_values(self, v2_db: orm.Session):
+        """Test storing maximum 32-bit integer values."""
+        instrument = Instrument(name="Test Instrument 10", properties={})
+        observation = Observation(
+            cadence_reference=np.array([1, 2]),
+            instrument=instrument,
+        )
+        v2_db.add_all([instrument, observation])
+        v2_db.flush()
+
+        # Test with maximum signed 32-bit value
+        max_int32 = np.iinfo(np.int32).max  # 2147483647
+        quality_flags = QualityFlagArray(
+            observation=observation,
+            quality_flags=np.array([max_int32, 0], dtype=np.int32),
+        )
+        v2_db.add(quality_flags)
+        v2_db.commit()
+
+        # Verify stored correctly
+        assert quality_flags.quality_flags[0] == max_int32
+
+
+class TestQualityFlagArrayPolymorphism:
+    """Test polymorphic behavior of QualityFlagArray."""
+
+    def test_polymorphic_identity(self, v2_db: orm.Session):
+        """Test that type field works as polymorphic discriminator."""
+        instrument = Instrument(name="Test Instrument 11", properties={})
+        observation = Observation(
+            cadence_reference=np.array([1, 2]),
+            instrument=instrument,
+        )
+        v2_db.add_all([instrument, observation])
+        v2_db.flush()
+
+        # Create quality flags (all will have base_quality_flag type)
+        # Testing polymorphism with different targets
+        mission = Mission(
+            id=uuid.uuid4(),
+            name="TEST_MISSION_POLY",
+            description="Test Mission Poly",
+            time_unit="day",
+            time_epoch=0.0,
+            time_epoch_scale="tdb",
+            time_epoch_format="jd",
+            time_format_name="test_time_poly",
+        )
+        catalog = MissionCatalog(
+            name="TEST_CATALOG_POLY",
+            description="Test Catalog Poly",
+            host_mission=mission,
+        )
+        target1 = Target(name=111111, catalog=catalog)
+        target2 = Target(name=222222, catalog=catalog)
+        v2_db.add_all([mission, catalog, target1, target2])
+        v2_db.flush()
+
+        pixel_flags = QualityFlagArray(
+            observation=observation,
+            target=target1,  # Different target
+            quality_flags=np.array([0, 1], dtype=np.int32),
+        )
+        aperture_flags = QualityFlagArray(
+            observation=observation,
+            target=target2,  # Different target
+            quality_flags=np.array([1, 0], dtype=np.int32),
+        )
+        v2_db.add_all([pixel_flags, aperture_flags])
+        v2_db.commit()
+
+        # Query by target instead since type will be base_quality_flag
+        target1_results = (
+            v2_db.query(QualityFlagArray).filter_by(target_id=target1.id).all()
+        )
+        assert len(target1_results) == 1
+        assert target1_results[0] == pixel_flags
+
+        target2_results = (
+            v2_db.query(QualityFlagArray).filter_by(target_id=target2.id).all()
+        )
+        assert len(target2_results) == 1
+        assert target2_results[0] == aperture_flags
+
+    def test_polymorphic_subclass(self, v2_db: orm.Session):
+        """Test creating a subclass of QualityFlagArray."""
+
+        # Define a custom quality flag subclass
+        class TESSQualityFlags(QualityFlagArray):
+            """TESS-specific quality flags with known bit definitions."""
+
+            __mapper_args__ = {
+                "polymorphic_identity": "tess_quality",
+            }
+
+            @property
+            def cosmic_ray_events(self):
+                """Return mask of cosmic ray events (bit 0)."""
+                flags = np.array(self.quality_flags, dtype=np.int32)
+                return (flags & 1) != 0
+
+            @property
+            def saturated_pixels(self):
+                """Return mask of saturated pixels (bit 1)."""
+                flags = np.array(self.quality_flags, dtype=np.int32)
+                return (flags & 2) != 0
+
+        # Use the subclass
+        instrument = Instrument(name="TESS Camera", properties={})
+        observation = Observation(
+            cadence_reference=np.array([1, 2, 3]),
+            instrument=instrument,
+        )
+        v2_db.add_all([instrument, observation])
+        v2_db.flush()
+
+        tess_flags = TESSQualityFlags(
+            observation=observation,
+            quality_flags=np.array([0, 1, 3], dtype=np.int32),
+        )
+        v2_db.add(tess_flags)
+        v2_db.commit()
+
+        # Verify polymorphic loading
+        loaded = (
+            v2_db.query(QualityFlagArray).filter_by(id=tess_flags.id).first()
+        )
+        assert isinstance(loaded, TESSQualityFlags)
+
+        # Test custom properties
+        assert np.array_equal(loaded.cosmic_ray_events, [False, True, True])
+        assert np.array_equal(loaded.saturated_pixels, [False, False, True])


### PR DESCRIPTION
This pull request introduces a new feature for managing quality flag arrays in astronomical observations, alongside supporting changes to the codebase and documentation. The most significant updates include the addition of the `QualityFlagArray` model, integration with existing models, and updates to the documentation and test suite.

### New Feature: Quality Flag Arrays

* **`QualityFlagArray` Model**: Introduced a new model `QualityFlagArray` to store bit-encoded quality flags for observations. This model supports polymorphism for mission-specific extensions and includes relationships with `Observation` and `Target`.

### Integration with Existing Models

* **`Observation` Model**: Added a `quality_flag_arrays` relationship to link observations with their quality flags.
* **`Target` Model**: Added a `quality_flag_arrays` relationship for target-specific quality flags.
* **Type Annotations and Imports**: Updated type hints and imports in `observation.py` and `target.py` to include `QualityFlagArray`. [[1]](diffhunk://#diff-c27e9e6283dc6b4759a6237175465a912792f432d48319620e103bb29088010cR14) [[2]](diffhunk://#diff-e97931ac485ef7969905b0dc93a3be3579cdf4bf3791e6fbfa7a24c3800ddf7dR17)

### Documentation Updates

* **Database Documentation**: Added `:no-index:` directive to `configure_engine` in the database documentation.
* **Model Documentation**: Documented the `QualityFlagArray` model in the `Observation Models` section, excluding the `created_on` attribute.

### Test Suite Enhancements

* **Factory for `QualityFlagArray`**: Added a new hypothesis strategy, `quality_flag_array`, to generate test instances of the `QualityFlagArray` model.
* **Numpy Import**: Added `numpy` import to `tests/factories.py` to support the new strategy.

### Miscellaneous

* **Type Mapping Update**: Extended the type mapping in `LCDBModel` to support `npt.NDArray[np.int32]` for 32-bit integer arrays.
* **Model Initialization**: Added `QualityFlagArray` to the `__all__` and `DEFINED_MODELS` lists in `models/__init__.py`. [[1]](diffhunk://#diff-323e28d70ec8f5e5376635c8a34c986f7c9a0ad3199976af56bb2b8169fd8d99R10) [[2]](diffhunk://#diff-323e28d70ec8f5e5376635c8a34c986f7c9a0ad3199976af56bb2b8169fd8d99R25)