### PR TITLE
feat: Add dynamic coverage badge to README

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,13 +53,27 @@ jobs:
         pytest -v --cov=lightcurvedb --cov-report=term-missing
 
     - name: Generate coverage report
-      if: matrix.python-version == '3.11'
+      if: matrix.python-version == '3.12'
       run: |
         pytest --cov=lightcurvedb --cov-report=xml
 
-    - name: Upload coverage to Codecov
-      if: matrix.python-version == '3.11'
-      uses: codecov/codecov-action@v3
+    - name: Extract coverage percentage
+      if: matrix.python-version == '3.12'
+      id: coverage
+      run: |
+        COVERAGE=$(python -c "import xml.etree.ElementTree as ET; tree = ET.parse('coverage.xml'); print(f\"{float(tree.getroot().attrib['line-rate']) * 100:.0f}\")")
+        echo "percentage=$COVERAGE" >> $GITHUB_OUTPUT
+        echo "Coverage: $COVERAGE%"
+
+    - name: Update coverage badge
+      if: matrix.python-version == '3.12' && github.ref == 'refs/heads/staging'
+      uses: schneegans/dynamic-badges-action@v1.7.0
       with:
-        file: ./coverage.xml
-        fail_ci_if_error: false
+        auth: ${{ secrets.GIST_TOKEN }}
+        gistID: ${{ vars.COVERAGE_GIST_ID }}
+        filename: coverage-badge.json
+        label: coverage
+        message: ${{ steps.coverage.outputs.percentage }}%
+        valColorRange: ${{ steps.coverage.outputs.percentage }}
+        maxColorRange: 100
+        minColorRange: 0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,7 +66,7 @@ jobs:
         echo "Coverage: $COVERAGE%"
 
     - name: Update coverage badge
-      if: matrix.python-version == '3.12' && github.ref == 'refs/heads/staging'
+      if: matrix.python-version == '3.12' && (github.ref == 'refs/heads/staging' || github.ref == 'refs/heads/master')
       uses: schneegans/dynamic-badges-action@v1.7.0
       with:
         auth: ${{ secrets.GIST_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Welcome to the readme
 
 ![Tests](https://github.com/mit-kavli-institute/lightcurvedb/actions/workflows/test.yml/badge.svg?branch=staging)
-![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/mit-kavli-institute/COVERAGE_GIST_ID/raw/coverage-badge.json)
+![Coverage](https://img.shields.io/endpoint?url=https://gist.github.com/WilliamCFong/370ef4b4b1e8b673957a122a4d7f27bc)
 
 ## Installation
 There are a couple of ways of installing `lightcurvedb`.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Welcome to the readme
 
+![Tests](https://github.com/mit-kavli-institute/lightcurvedb/actions/workflows/test.yml/badge.svg?branch=staging)
+![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/mit-kavli-institute/COVERAGE_GIST_ID/raw/coverage-badge.json)
+
 ## Installation
 There are a couple of ways of installing `lightcurvedb`.
 1. Clone and install this repository and install using `cd lightcurvedb && pip install .`, this will install the required dependencies as well.


### PR DESCRIPTION
## Summary

- Add dynamic coverage badge to README that updates automatically on CI runs
- Extract coverage percentage from pytest XML report
- Use Gist-based badge via `schneegans/dynamic-badges-action`
- Badge updates on pushes to `staging` and `master` branches

## Setup Checklist

Before the badge will work, complete these steps:

- [x] **Create a GitHub Gist**
  1. Go to https://gist.github.com
  2. Create a new Gist (can be secret) with any filename (e.g., `coverage-badge.json`)
  3. Copy the Gist ID from the URL (the long alphanumeric string)

- [x] **Add repository secret: `GIST_TOKEN`**
  1. Create a Personal Access Token at https://github.com/settings/tokens
  2. Grant the `gist` scope only
  3. Add as repository secret: Settings → Secrets and variables → Actions → New repository secret

- [x] **Add repository variable: `COVERAGE_GIST_ID`**
  1. Go to Settings → Secrets and variables → Actions → Variables tab
  2. Add new variable named `COVERAGE_GIST_ID` with the Gist ID from step 1

- [x] **Update README badge URL**
  1. Replace `COVERAGE_GIST_ID` in the badge URL with actual Gist ID
  2. Replace `mit-kavli-institute` with the Gist owner's username if different

## Test plan

- [ ] Merge PR and push to staging
- [ ] Verify GitHub Actions workflow completes successfully
- [ ] Check that the Gist is updated with coverage JSON
- [ ] Verify badge displays correctly in README

🤖 Generated with [Claude Code](https://claude.com/claude-code)