### PR TITLE
removing unique constraint on FITS Frame model as it was too strict, …

### DIFF
--- a/src/lightcurvedb/models/frame.py
+++ b/src/lightcurvedb/models/frame.py
@@ -55,14 +55,6 @@ class FITSFrame(LCDBModel, CreatedOnMixin):
         "polymorphic_on": "type",
     }
 
-    __table_args__ = (
-        sa.UniqueConstraint(
-            "type",
-            "cadence",
-            name="distinct_frame_type_cadence_idx",
-        ),
-    )
-
     id: orm.Mapped[int] = orm.mapped_column(primary_key=True)
     type: orm.Mapped[str] = orm.mapped_column(index=True)
     cadence: orm.Mapped[int] = orm.mapped_column(sa.BigInteger, index=True)


### PR DESCRIPTION
This pull request makes a targeted change to the `FITSFrame` model by removing a uniqueness constraint from the table definition. This simplifies the database schema and may allow for more flexible data storage.

Database schema update:

* Removed the `sa.UniqueConstraint` enforcing uniqueness on the combination of `type` and `cadence` columns from the `FITSFrame` table definition in `frame.py`.