### PR TITLE
feat: add __repr__ methods to all SQLAlchemy models

### DIFF
--- a/src/lightcurvedb/core/base_model.py
+++ b/src/lightcurvedb/core/base_model.py
@@ -33,6 +33,15 @@ class LCDBModel(orm.DeclarativeBase):
         pathlib.Path: sa.String,
     }
 
+    def __repr__(self) -> str:
+        """Default repr for LCDB models. Shows class name and primary keys."""
+        mapper = sa.inspect(self.__class__)
+        pk_cols = [col.name for col in mapper.primary_key]
+        pk_values = ", ".join(
+            f"{col}={getattr(self, col, '?')!r}" for col in pk_cols
+        )
+        return f"<{self.__class__.__name__}({pk_values})>"
+
 
 @orm.declarative_mixin
 class CreatedOnMixin:

--- a/src/lightcurvedb/models/dataset.py
+++ b/src/lightcurvedb/models/dataset.py
@@ -84,6 +84,9 @@ class PhotometricSource(LCDBModel, NameAndDescriptionMixin):
             session.flush()
         return sentinel
 
+    def __repr__(self) -> str:
+        return f"<PhotometricSource(id={self.id!r}, name={self.name!r})>"
+
 
 class ProcessingMethod(LCDBModel, NameAndDescriptionMixin):
     """
@@ -152,6 +155,9 @@ class ProcessingMethod(LCDBModel, NameAndDescriptionMixin):
             session.add(sentinel)
             session.flush()
         return sentinel
+
+    def __repr__(self) -> str:
+        return f"<ProcessingMethod(id={self.id!r}, name={self.name!r})>"
 
 
 class DataSetHierarchy(LCDBModel):
@@ -275,6 +281,15 @@ class DataSetHierarchy(LCDBModel):
     child_processing_method_id: orm.Mapped[int] = orm.mapped_column(
         nullable=False
     )
+
+    def __repr__(self) -> str:
+        return (
+            f"<DataSetHierarchy("
+            f"source=(obs={self.source_observation_id}, "
+            f"target={self.source_target_id}) -> "
+            f"child=(obs={self.child_observation_id}, "
+            f"target={self.child_target_id}))>"
+        )
 
 
 class DataSet(LCDBModel):
@@ -636,3 +651,10 @@ class DataSet(LCDBModel):
                 self.errors,
                 fill_value=fill_value,
             )
+
+    def __repr__(self) -> str:
+        return (
+            f"<DataSet(obs={self.observation_id}, target={self.target_id}, "
+            f"phot={self.photometric_method_id}, "
+            f"proc={self.processing_method_id})>"
+        )

--- a/src/lightcurvedb/models/frame.py
+++ b/src/lightcurvedb/models/frame.py
@@ -80,3 +80,9 @@ class FITSFrame(LCDBModel, CreatedOnMixin):
     observation: orm.Mapped["Observation"] = orm.relationship(
         "Observation", back_populates="fits_images"
     )
+
+    def __repr__(self) -> str:
+        return (
+            f"<{self.__class__.__name__}(id={self.id!r}, type={self.type!r}, "
+            f"cadence={self.cadence!r}, obs={self.observation_id!r})>"
+        )

--- a/src/lightcurvedb/models/instrument.py
+++ b/src/lightcurvedb/models/instrument.py
@@ -86,3 +86,7 @@ class Instrument(LCDBModel):
         else:
             q = q.where(cls.parent_id.is_(None))
         return q
+
+    def __repr__(self) -> str:
+        parent_str = f", parent={self.parent_id!s}" if self.parent_id else ""
+        return f"<Instrument(id={self.id!s}, name={self.name!r}{parent_str})>"

--- a/src/lightcurvedb/models/observation.py
+++ b/src/lightcurvedb/models/observation.py
@@ -156,6 +156,12 @@ class Observation(LCDBModel):
 
         return result
 
+    def __repr__(self) -> str:
+        return (
+            f"<{self.__class__.__name__}(id={self.id!r}, type={self.type!r}, "
+            f"instrument={self.instrument_id!s})>"
+        )
+
 
 class TargetSpecificTime(LCDBModel):
     """
@@ -206,6 +212,12 @@ class TargetSpecificTime(LCDBModel):
     observation: orm.Mapped["Observation"] = orm.relationship(
         back_populates="target_specific_times"
     )
+
+    def __repr__(self) -> str:
+        return (
+            f"<TargetSpecificTime(id={self.id!r}, target={self.target_id!r}, "
+            f"obs={self.observation_id!r})>"
+        )
 
 
 # Create unique constraint on (target_id, observation_id)

--- a/src/lightcurvedb/models/quality_flag.py
+++ b/src/lightcurvedb/models/quality_flag.py
@@ -248,6 +248,13 @@ class QualityFlagArray(LCDBModel, CreatedOnMixin):
         "Target", back_populates="quality_flag_arrays"
     )
 
+    def __repr__(self) -> str:
+        target_str = f", target={self.target_id!r}" if self.target_id else ""
+        return (
+            f"<{self.__class__.__name__}(id={self.id!r}, type={self.type!r}, "
+            f"obs={self.observation_id!r}{target_str})>"
+        )
+
 
 # Create unique index that treats NULL target_id values as equal
 # This ensures only one quality flag array per (type, observation_id,

--- a/src/lightcurvedb/models/target.py
+++ b/src/lightcurvedb/models/target.py
@@ -84,6 +84,9 @@ class Mission(LCDBModel, NameAndDescriptionMixin, CreatedOnMixin):
         back_populates="host_mission"
     )
 
+    def __repr__(self) -> str:
+        return f"<Mission(id={self.id!s}, name={self.name!r})>"
+
 
 class MissionCatalog(LCDBModel, NameAndDescriptionMixin, CreatedOnMixin):
     """
@@ -124,6 +127,12 @@ class MissionCatalog(LCDBModel, NameAndDescriptionMixin, CreatedOnMixin):
     targets: orm.Mapped[list["Target"]] = orm.relationship(
         back_populates="catalog"
     )
+
+    def __repr__(self) -> str:
+        return (
+            f"<MissionCatalog(id={self.id!r}, name={self.name!r}, "
+            f"mission={self.host_mission_id!s})>"
+        )
 
 
 class Target(LCDBModel):
@@ -185,3 +194,9 @@ class Target(LCDBModel):
     quality_flag_arrays: orm.Mapped[
         list["QualityFlagArray"]
     ] = orm.relationship(back_populates="target")
+
+    def __repr__(self) -> str:
+        return (
+            f"<Target(id={self.id!r}, catalog={self.catalog_id!r}, "
+            f"name={self.name!r})>"
+        )


### PR DESCRIPTION
## Summary

- Add descriptive `__repr__` methods to all 12 SQLAlchemy models for better debugging and logging
- Add default fallback `__repr__` to `LCDBModel` base class using SQLAlchemy inspection to dynamically show primary keys
- Polymorphic subclasses get sensible representations via `self.__class__.__name__`

## Models Updated

| File | Models |
|------|--------|
| `src/lightcurvedb/core/base_model.py` | LCDBModel (default fallback) |
| `src/lightcurvedb/models/dataset.py` | PhotometricSource, ProcessingMethod, DataSetHierarchy, DataSet |
| `src/lightcurvedb/models/frame.py` | FITSFrame |
| `src/lightcurvedb/models/instrument.py` | Instrument |
| `src/lightcurvedb/models/observation.py` | Observation, TargetSpecificTime |
| `src/lightcurvedb/models/quality_flag.py` | QualityFlagArray |
| `src/lightcurvedb/models/target.py` | Mission, MissionCatalog, Target |

## Test plan

- [x] All files pass syntax validation
- [x] All pre-commit hooks pass (flake8, black, isort, commitizen)
- [x] Run test suite to verify no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)