### PR TITLE
Partition TargetSpecificTime and DataSetHierarchy by observation_id

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,6 @@
-FROM thekevjames/nox
-
-COPY docker_runner /root/.ssh/id_rsa
-COPY tests/ssh-config /root/ssh/config
-
-RUN touch /root/.ssh/known_hosts && ssh-keyscan tessgit.mit.edu >> /root/.ssh/known_hosts
+FROM acidrain/multi-python
 
 RUN apt-get update && apt-get install -y postgresql libpq-dev
+RUN pip install nox
+
 CMD ["tail", "-f", "/dev/null"]

--- a/src/lightcurvedb/models/dataset.py
+++ b/src/lightcurvedb/models/dataset.py
@@ -260,6 +260,7 @@ class DataSetHierarchy(LCDBModel):
             "child_photometric_method_id",
             "child_processing_method_id",
         ),
+        {"postgresql_partition_by": "LIST (source_observation_id)"},
     )
 
     # Source dataset composite key columns

--- a/src/lightcurvedb/models/observation.py
+++ b/src/lightcurvedb/models/observation.py
@@ -76,11 +76,11 @@ class Observation(LCDBModel):
         ),
         sa.Index(
             "ix_observation_cadence_min",
-            sa.column("cadence_reference")[1],
+            sa.column("cadence_reference", type_=sa.ARRAY(sa.BIGINT))[1],
         ),
         sa.Index(
             "ix_observation_cadence_max",
-            sa.column("cadence_reference")[
+            sa.column("cadence_reference", type_=sa.ARRAY(sa.BIGINT))[
                 sa.func.cardinality(sa.column("cadence_reference"))
             ],
         ),

--- a/src/lightcurvedb/models/observation.py
+++ b/src/lightcurvedb/models/observation.py
@@ -69,6 +69,22 @@ class Observation(LCDBModel):
         "polymorphic_identity": "observation",
         "polymorphic_on": "type",
     }
+    __table_args__ = (
+        sa.Index(
+            "ix_observation_cadence_length",
+            sa.func.cardinality(sa.column("cadence_reference")),
+        ),
+        sa.Index(
+            "ix_observation_cadence_min",
+            sa.column("cadence_reference")[1],
+        ),
+        sa.Index(
+            "ix_observation_cadence_max",
+            sa.column("cadence_reference")[
+                sa.func.cardinality(sa.column("cadence_reference"))
+            ],
+        ),
+    )
 
     id: orm.Mapped[int] = orm.mapped_column(primary_key=True)
     type: orm.Mapped[str] = orm.mapped_column(index=True)
@@ -171,14 +187,15 @@ class TargetSpecificTime(LCDBModel):
     for the specific position of a target. It serves as a junction
     between Target and Observation with additional time data.
 
+    Uses a composite primary key (observation_id, target_id) and is
+    partitioned by observation_id using PostgreSQL LIST partitioning.
+
     Attributes
     ----------
-    id : int
-        Primary key identifier
-    target_id : int
-        Foreign key to the target
     observation_id : int
-        Foreign key to the observation
+        Foreign key to the observation (part of composite PK, partition key)
+    target_id : int
+        Foreign key to the target (part of composite PK)
     barycentric_julian_dates : ndarray[float64]
         Array of barycentric Julian dates corrected for target position
     target : Target
@@ -195,12 +212,21 @@ class TargetSpecificTime(LCDBModel):
 
     __tablename__ = "target_specific_time"
 
-    id: orm.Mapped[int] = orm.mapped_column(sa.BigInteger, primary_key=True)
-    target_id: orm.Mapped[int] = orm.mapped_column(
-        sa.ForeignKey("target.id", ondelete="CASCADE"), index=True
+    __table_args__ = (
+        sa.PrimaryKeyConstraint(
+            "observation_id", "target_id", name="pk_target_specific_time"
+        ),
+        {"postgresql_partition_by": "LIST (observation_id)"},
     )
+
     observation_id: orm.Mapped[int] = orm.mapped_column(
-        sa.ForeignKey(Observation.id, ondelete="CASCADE"), index=True
+        sa.ForeignKey("observation.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    target_id: orm.Mapped[int] = orm.mapped_column(
+        sa.ForeignKey("target.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
     )
 
     barycentric_julian_dates: orm.Mapped[npt.NDArray[np.float64]]
@@ -215,16 +241,6 @@ class TargetSpecificTime(LCDBModel):
 
     def __repr__(self) -> str:
         return (
-            f"<TargetSpecificTime(id={self.id!r}, target={self.target_id!r}, "
-            f"obs={self.observation_id!r})>"
+            f"<TargetSpecificTime(obs={self.observation_id!r}, "
+            f"target={self.target_id!r})>"
         )
-
-
-# Create unique constraint on (target_id, observation_id)
-# This ensures only one TargetSpecificTime per target-observation pair
-sa.Index(
-    "unique_target_observation_time",
-    TargetSpecificTime.target_id,
-    TargetSpecificTime.observation_id,
-    unique=True,
-)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -141,6 +141,18 @@ def v2_db(worker_database):
                 "PARTITION OF dataset DEFAULT"
             )
         )
+        conn.execute(
+            sa.text(
+                "CREATE TABLE IF NOT EXISTS target_specific_time_default "
+                "PARTITION OF target_specific_time DEFAULT"
+            )
+        )
+        conn.execute(
+            sa.text(
+                "CREATE TABLE IF NOT EXISTS datasethierarchy_default "
+                "PARTITION OF datasethierarchy DEFAULT"
+            )
+        )
         conn.commit()
 
     Session = sessionmaker()

--- a/tests/test_observation.py
+++ b/tests/test_observation.py
@@ -479,7 +479,7 @@ class TestObservationConstraints:
 
         obs_id = observation.id
         qf_id = quality_flags.id
-        tst_id = tst.id
+        tst_obs_id, tst_target_id = tst.observation_id, tst.target_id
 
         # Delete observation
         v2_db.execute(delete(Observation).where(Observation.id == obs_id))
@@ -493,7 +493,9 @@ class TestObservationConstraints:
             v2_db.query(QualityFlagArray).filter_by(id=qf_id).first() is None
         )
         assert (
-            v2_db.query(TargetSpecificTime).filter_by(id=tst_id).first()
+            v2_db.query(TargetSpecificTime)
+            .filter_by(observation_id=tst_obs_id, target_id=tst_target_id)
+            .first()
             is None
         )
 

--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -511,7 +511,7 @@ class TestTargetConstraints:
         v2_db.commit()
 
         target_id = target.id
-        tst_id = tst.id
+        tst_obs_id = tst.observation_id
 
         # Delete target - related objects should handle this appropriately
         v2_db.execute(delete(Target).where(Target.id == target.id))
@@ -522,7 +522,9 @@ class TestTargetConstraints:
 
         # Verify TargetSpecificTime is deleted via cascade
         assert (
-            v2_db.query(TargetSpecificTime).filter_by(id=tst_id).first()
+            v2_db.query(TargetSpecificTime)
+            .filter_by(observation_id=tst_obs_id, target_id=target_id)
+            .first()
             is None
         )
 

--- a/tests/test_target_specific_time.py
+++ b/tests/test_target_specific_time.py
@@ -62,7 +62,7 @@ class TestTargetSpecificTimeBasics:
         v2_db.commit()
 
         # Verify creation
-        assert tst.id is not None
+        assert tst.observation_id == observation.id
         assert tst.target_id == target.id
         assert tst.observation_id == observation.id
         assert np.array_equal(tst.barycentric_julian_dates, bjd_array)
@@ -618,8 +618,7 @@ class TestTargetSpecificTimeConstraints:
         v2_db.add(tst)
         v2_db.commit()
 
-        tst_id = tst.id
-        target_id = target.id
+        obs_id, target_id = tst.observation_id, tst.target_id
 
         # Delete target
         v2_db.delete(target)
@@ -630,7 +629,9 @@ class TestTargetSpecificTimeConstraints:
 
         # Verify TST is also deleted (cascade)
         assert (
-            v2_db.query(TargetSpecificTime).filter_by(id=tst_id).first()
+            v2_db.query(TargetSpecificTime)
+            .filter_by(observation_id=obs_id, target_id=target_id)
+            .first()
             is None
         )
 
@@ -672,7 +673,7 @@ class TestTargetSpecificTimeConstraints:
         v2_db.add(tst)
         v2_db.commit()
 
-        tst_id = tst.id
+        target_id = tst.target_id
         obs_id = observation.id
 
         # Delete observation
@@ -684,7 +685,9 @@ class TestTargetSpecificTimeConstraints:
 
         # Verify TST is also deleted (cascade)
         assert (
-            v2_db.query(TargetSpecificTime).filter_by(id=tst_id).first()
+            v2_db.query(TargetSpecificTime)
+            .filter_by(observation_id=obs_id, target_id=target_id)
+            .first()
             is None
         )
 


### PR DESCRIPTION
## Summary

- **TargetSpecificTime**: Replace scalar `id` PK with composite PK `(observation_id, target_id)` and add PostgreSQL LIST partitioning by `observation_id`
- **DataSetHierarchy**: Add LIST partitioning by `source_observation_id`
- **Observation indexes**: Fix `sa.column()` calls to provide `type_=sa.ARRAY(sa.BIGINT)` so array subscript indexing works in SQLAlchemy 2.0+
- **Dockerfile**: Switch from deprecated `thekevjames/nox` to `acidrain/multi-python`

## Test plan

- [x] `docker-compose run --rm tester nox -s property_tests` passes
- [x] Cascade delete tests pass for TargetSpecificTime (from target and observation)
- [x] Default partitions created correctly in test conftest


🤖 Generated with [Claude Code](https://claude.com/claude-code)