### PR TITLE
Add Rich formatting support to all SQLAlchemy models

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "packaging>=23.2",
     "tabulate>=0.9.0",
     "kavli-configurables",
+    "rich>=13",
 ]
 
 

--- a/src/lightcurvedb/core/base_model.py
+++ b/src/lightcurvedb/core/base_model.py
@@ -12,6 +12,18 @@ from sqlalchemy.dialects.postgresql import JSONB
 from lightcurvedb.core.types import NumpyArrayType
 
 
+def _format_array_summary(arr) -> str:
+    """Format a numpy array as a compact summary string."""
+    if arr is None:
+        return "None"
+    if not isinstance(arr, np.ndarray):
+        return repr(arr)
+    if len(arr) <= 6:
+        return repr(arr.tolist())
+    dtype = arr.dtype
+    return f"{dtype}[{len(arr)}] range=[{arr.min()}, {arr.max()}]"
+
+
 class LCDBModel(orm.DeclarativeBase):
     """
     A common SQLAlchemy base model for LCDB v2 models.
@@ -41,6 +53,28 @@ class LCDBModel(orm.DeclarativeBase):
             f"{col}={getattr(self, col, '?')!r}" for col in pk_cols
         )
         return f"<{self.__class__.__name__}({pk_values})>"
+
+    def __rich_repr__(self):
+        mapper = sa.inspect(self.__class__)
+        pk_cols = [col.name for col in mapper.primary_key]
+        for col in pk_cols:
+            yield col, getattr(self, col, None)
+
+    def __rich_console__(self, console, options):
+        from rich.table import Table
+
+        table = Table(title=self.__class__.__name__, show_header=True)
+        table.add_column("Field", style="bold cyan")
+        table.add_column("Value")
+        mapper = sa.inspect(self.__class__)
+        for col in mapper.columns:
+            val = getattr(self, col.key, None)
+            if isinstance(val, np.ndarray):
+                display = _format_array_summary(val)
+            else:
+                display = repr(val)
+            table.add_row(col.key, display)
+        yield table
 
 
 @orm.declarative_mixin

--- a/src/lightcurvedb/models/dataset.py
+++ b/src/lightcurvedb/models/dataset.py
@@ -87,6 +87,10 @@ class PhotometricSource(LCDBModel, NameAndDescriptionMixin):
     def __repr__(self) -> str:
         return f"<PhotometricSource(id={self.id!r}, name={self.name!r})>"
 
+    def __rich_repr__(self):
+        yield "id", self.id
+        yield "name", self.name
+
 
 class ProcessingMethod(LCDBModel, NameAndDescriptionMixin):
     """
@@ -158,6 +162,10 @@ class ProcessingMethod(LCDBModel, NameAndDescriptionMixin):
 
     def __repr__(self) -> str:
         return f"<ProcessingMethod(id={self.id!r}, name={self.name!r})>"
+
+    def __rich_repr__(self):
+        yield "id", self.id
+        yield "name", self.name
 
 
 class DataSetHierarchy(LCDBModel):
@@ -291,6 +299,12 @@ class DataSetHierarchy(LCDBModel):
             f"child=(obs={self.child_observation_id}, "
             f"target={self.child_target_id}))>"
         )
+
+    def __rich_repr__(self):
+        yield "source_obs", self.source_observation_id
+        yield "source_target", self.source_target_id
+        yield "child_obs", self.child_observation_id
+        yield "child_target", self.child_target_id
 
 
 class DataSet(LCDBModel):
@@ -659,3 +673,9 @@ class DataSet(LCDBModel):
             f"phot={self.photometric_method_id}, "
             f"proc={self.processing_method_id})>"
         )
+
+    def __rich_repr__(self):
+        yield "obs", self.observation_id
+        yield "target", self.target_id
+        yield "phot", self.photometric_method_id
+        yield "proc", self.processing_method_id

--- a/src/lightcurvedb/models/frame.py
+++ b/src/lightcurvedb/models/frame.py
@@ -86,3 +86,9 @@ class FITSFrame(LCDBModel, CreatedOnMixin):
             f"<{self.__class__.__name__}(id={self.id!r}, type={self.type!r}, "
             f"cadence={self.cadence!r}, obs={self.observation_id!r})>"
         )
+
+    def __rich_repr__(self):
+        yield "id", self.id
+        yield "type", self.type
+        yield "cadence", self.cadence
+        yield "obs", self.observation_id

--- a/src/lightcurvedb/models/instrument.py
+++ b/src/lightcurvedb/models/instrument.py
@@ -90,3 +90,9 @@ class Instrument(LCDBModel):
     def __repr__(self) -> str:
         parent_str = f", parent={self.parent_id!s}" if self.parent_id else ""
         return f"<Instrument(id={self.id!s}, name={self.name!r}{parent_str})>"
+
+    def __rich_repr__(self):
+        yield "id", self.id
+        yield "name", self.name
+        if self.parent_id:
+            yield "parent", self.parent_id

--- a/src/lightcurvedb/models/observation.py
+++ b/src/lightcurvedb/models/observation.py
@@ -178,6 +178,11 @@ class Observation(LCDBModel):
             f"instrument={self.instrument_id!s})>"
         )
 
+    def __rich_repr__(self):
+        yield "id", self.id
+        yield "type", self.type
+        yield "instrument", self.instrument_id
+
 
 class TargetSpecificTime(LCDBModel):
     """
@@ -244,3 +249,7 @@ class TargetSpecificTime(LCDBModel):
             f"<TargetSpecificTime(obs={self.observation_id!r}, "
             f"target={self.target_id!r})>"
         )
+
+    def __rich_repr__(self):
+        yield "observation_id", self.observation_id
+        yield "target_id", self.target_id

--- a/src/lightcurvedb/models/quality_flag.py
+++ b/src/lightcurvedb/models/quality_flag.py
@@ -255,6 +255,13 @@ class QualityFlagArray(LCDBModel, CreatedOnMixin):
             f"obs={self.observation_id!r}{target_str})>"
         )
 
+    def __rich_repr__(self):
+        yield "id", self.id
+        yield "type", self.type
+        yield "obs", self.observation_id
+        if self.target_id:
+            yield "target", self.target_id
+
 
 # Create unique index that treats NULL target_id values as equal
 # This ensures only one quality flag array per (type, observation_id,

--- a/src/lightcurvedb/models/target.py
+++ b/src/lightcurvedb/models/target.py
@@ -87,6 +87,10 @@ class Mission(LCDBModel, NameAndDescriptionMixin, CreatedOnMixin):
     def __repr__(self) -> str:
         return f"<Mission(id={self.id!s}, name={self.name!r})>"
 
+    def __rich_repr__(self):
+        yield "id", self.id
+        yield "name", self.name
+
 
 class MissionCatalog(LCDBModel, NameAndDescriptionMixin, CreatedOnMixin):
     """
@@ -133,6 +137,11 @@ class MissionCatalog(LCDBModel, NameAndDescriptionMixin, CreatedOnMixin):
             f"<MissionCatalog(id={self.id!r}, name={self.name!r}, "
             f"mission={self.host_mission_id!s})>"
         )
+
+    def __rich_repr__(self):
+        yield "id", self.id
+        yield "name", self.name
+        yield "mission", self.host_mission_id
 
 
 class Target(LCDBModel):
@@ -200,3 +209,8 @@ class Target(LCDBModel):
             f"<Target(id={self.id!r}, catalog={self.catalog_id!r}, "
             f"name={self.name!r})>"
         )
+
+    def __rich_repr__(self):
+        yield "id", self.id
+        yield "catalog", self.catalog_id
+        yield "name", self.name

--- a/tests/test_rich_formatting.py
+++ b/tests/test_rich_formatting.py
@@ -1,0 +1,308 @@
+"""Tests for Rich formatting support on LCDB models.
+
+All tests are pure unit tests — no database session required since we only
+access model attributes set via constructor, not persisted data.
+"""
+
+import uuid
+
+import numpy as np
+from rich.console import Console
+
+from lightcurvedb.core.base_model import LCDBModel, _format_array_summary
+from lightcurvedb.models import (
+    DataSet,
+    DataSetHierarchy,
+    FITSFrame,
+    Instrument,
+    Mission,
+    MissionCatalog,
+    Observation,
+    PhotometricSource,
+    ProcessingMethod,
+    QualityFlagArray,
+    Target,
+    TargetSpecificTime,
+)
+
+# ---------------------------------------------------------------------------
+# TestFormatArraySummary
+# ---------------------------------------------------------------------------
+
+
+class TestFormatArraySummary:
+    def test_none_input(self):
+        assert _format_array_summary(None) == "None"
+
+    def test_non_array_input(self):
+        assert _format_array_summary("hello") == repr("hello")
+
+    def test_empty_array(self):
+        arr = np.array([], dtype=np.int64)
+        assert _format_array_summary(arr) == "[]"
+
+    def test_small_array(self):
+        arr = np.array([1, 2, 3])
+        assert _format_array_summary(arr) == "[1, 2, 3]"
+
+    def test_exactly_six_elements(self):
+        arr = np.array([1, 2, 3, 4, 5, 6])
+        assert _format_array_summary(arr) == "[1, 2, 3, 4, 5, 6]"
+
+    def test_large_int_array(self):
+        arr = np.arange(100, dtype=np.int64)
+        result = _format_array_summary(arr)
+        assert result == "int64[100] range=[0, 99]"
+
+    def test_large_float_array(self):
+        arr = np.linspace(0, 1, 10)
+        result = _format_array_summary(arr)
+        assert "float64[10]" in result
+        assert "range=" in result
+        assert "0.0" in result
+        assert "1.0" in result
+
+
+# ---------------------------------------------------------------------------
+# TestRichReprOverrides
+# ---------------------------------------------------------------------------
+
+
+class TestRichReprOverrides:
+    def test_mission(self):
+        mid = uuid.uuid4()
+        m = Mission(
+            id=mid,
+            name="TESS",
+            description="Test mission",
+            time_unit="day",
+            time_epoch=2457000,
+            time_epoch_scale="tdb",
+            time_epoch_format="jd",
+            time_format_name="btjd",
+        )
+        pairs = list(m.__rich_repr__())
+        assert pairs == [("id", mid), ("name", "TESS")]
+
+    def test_mission_catalog(self):
+        mid = uuid.uuid4()
+        mc = MissionCatalog(
+            id=1,
+            name="TIC",
+            description="TESS Input Catalog",
+            host_mission_id=mid,
+        )
+        pairs = list(mc.__rich_repr__())
+        assert pairs == [("id", 1), ("name", "TIC"), ("mission", mid)]
+
+    def test_target(self):
+        t = Target(id=42, catalog_id=1, name=261136679)
+        pairs = list(t.__rich_repr__())
+        assert pairs == [("id", 42), ("catalog", 1), ("name", 261136679)]
+
+    def test_observation(self):
+        inst_id = uuid.uuid4()
+        o = Observation(
+            id=10,
+            type="observation",
+            cadence_reference=np.arange(10, dtype=np.int64),
+            instrument_id=inst_id,
+        )
+        pairs = list(o.__rich_repr__())
+        assert pairs == [
+            ("id", 10),
+            ("type", "observation"),
+            ("instrument", inst_id),
+        ]
+
+    def test_target_specific_time(self):
+        tst = TargetSpecificTime(
+            observation_id=1,
+            target_id=42,
+            barycentric_julian_dates=np.array([1.0, 2.0]),
+        )
+        pairs = list(tst.__rich_repr__())
+        assert pairs == [("observation_id", 1), ("target_id", 42)]
+
+    def test_instrument_without_parent(self):
+        inst_id = uuid.uuid4()
+        inst = Instrument(
+            id=inst_id, name="Camera 1", properties={}, parent_id=None
+        )
+        pairs = list(inst.__rich_repr__())
+        assert len(pairs) == 2
+        assert pairs == [("id", inst_id), ("name", "Camera 1")]
+
+    def test_instrument_with_parent(self):
+        inst_id = uuid.uuid4()
+        parent_id = uuid.uuid4()
+        inst = Instrument(
+            id=inst_id, name="Camera 1", properties={}, parent_id=parent_id
+        )
+        pairs = list(inst.__rich_repr__())
+        assert len(pairs) == 3
+        assert pairs == [
+            ("id", inst_id),
+            ("name", "Camera 1"),
+            ("parent", parent_id),
+        ]
+
+    def test_quality_flag_array_without_target(self):
+        qfa = QualityFlagArray(
+            id=5,
+            type="base_quality_flag",
+            observation_id=1,
+            target_id=None,
+            quality_flags=np.array([0, 1], dtype=np.int32),
+        )
+        pairs = list(qfa.__rich_repr__())
+        assert len(pairs) == 3
+        assert pairs == [
+            ("id", 5),
+            ("type", "base_quality_flag"),
+            ("obs", 1),
+        ]
+
+    def test_quality_flag_array_with_target(self):
+        qfa = QualityFlagArray(
+            id=5,
+            type="base_quality_flag",
+            observation_id=1,
+            target_id=42,
+            quality_flags=np.array([0, 1], dtype=np.int32),
+        )
+        pairs = list(qfa.__rich_repr__())
+        assert len(pairs) == 4
+        assert pairs == [
+            ("id", 5),
+            ("type", "base_quality_flag"),
+            ("obs", 1),
+            ("target", 42),
+        ]
+
+    def test_fits_frame(self):
+        ff = FITSFrame(
+            id=100,
+            type="basefits",
+            cadence=12345,
+            observation_id=1,
+            simple=True,
+            bitpix=16,
+            bscale=1.0,
+            bzero=0.0,
+            naxis=2,
+            naxis_values=[2048, 2048],
+            extended=True,
+        )
+        pairs = list(ff.__rich_repr__())
+        assert pairs == [
+            ("id", 100),
+            ("type", "basefits"),
+            ("cadence", 12345),
+            ("obs", 1),
+        ]
+
+    def test_photometric_source(self):
+        ps = PhotometricSource(
+            id=0, name="unspecified", description="No source specified"
+        )
+        pairs = list(ps.__rich_repr__())
+        assert pairs == [("id", 0), ("name", "unspecified")]
+
+    def test_processing_method(self):
+        pm = ProcessingMethod(
+            id=1, name="detrend-v1", description="Detrending v1"
+        )
+        pairs = list(pm.__rich_repr__())
+        assert pairs == [("id", 1), ("name", "detrend-v1")]
+
+    def test_dataset_hierarchy(self):
+        dsh = DataSetHierarchy(
+            source_observation_id=1,
+            source_target_id=10,
+            source_photometric_method_id=0,
+            source_processing_method_id=0,
+            child_observation_id=2,
+            child_target_id=20,
+            child_photometric_method_id=0,
+            child_processing_method_id=0,
+        )
+        pairs = list(dsh.__rich_repr__())
+        assert pairs == [
+            ("source_obs", 1),
+            ("source_target", 10),
+            ("child_obs", 2),
+            ("child_target", 20),
+        ]
+
+    def test_dataset(self):
+        ds = DataSet(
+            observation_id=1,
+            target_id=42,
+            photometric_method_id=0,
+            processing_method_id=0,
+            values=np.array([1.0, 2.0]),
+        )
+        pairs = list(ds.__rich_repr__())
+        assert pairs == [
+            ("obs", 1),
+            ("target", 42),
+            ("phot", 0),
+            ("proc", 0),
+        ]
+
+
+# ---------------------------------------------------------------------------
+# TestRichConsoleProtocol
+# ---------------------------------------------------------------------------
+
+
+class TestRichConsoleProtocol:
+    def _render(self, model) -> str:
+        console = Console(width=120, force_terminal=True)
+        with console.capture() as capture:
+            console.print(model)
+        return capture.get()
+
+    def test_photometric_source_console_output(self):
+        ps = PhotometricSource(
+            id=1, name="aperture", description="Simple aperture photometry"
+        )
+        output = self._render(ps)
+        assert "PhotometricSource" in output
+        assert "id" in output
+        assert "name" in output
+
+    def test_dataset_console_output_with_arrays(self):
+        ds = DataSet(
+            observation_id=1,
+            target_id=42,
+            photometric_method_id=0,
+            processing_method_id=0,
+            values=np.arange(100, dtype=np.float64),
+            errors=None,
+        )
+        output = self._render(ds)
+        assert "DataSet" in output
+        assert "observation_id" in output
+        assert "values" in output
+        # Array should be summarized, not printed in full
+        assert "float64[100]" in output
+
+
+# ---------------------------------------------------------------------------
+# TestDefaultRichRepr
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultRichRepr:
+    def test_base_rich_repr_yields_primary_keys(self):
+        """The base LCDBModel.__rich_repr__ yields PK columns."""
+        ps = PhotometricSource(id=99, name="test", description="Test source")
+        # Call the base class method directly, bypassing the override
+        pairs = list(LCDBModel.__rich_repr__(ps))
+        # PhotometricSource has a single PK column: id
+        assert ("id", 99) in pairs
+        # The base method should not yield non-PK columns
+        keys = [k for k, _ in pairs]
+        assert "name" not in keys


### PR DESCRIPTION
## Summary

- Add `__rich_repr__()` and `__rich_console__()` to `LCDBModel` base class with `_format_array_summary` helper for compact numpy array display
- Override `__rich_repr__()` on all 12 models with relevant field selections and conditional yields
- Add comprehensive unit tests (24 tests) covering the formatting helper, all model repr overrides, console protocol, and base class fallback
- Achieves 100% test coverage on `base_model.py`

## Test plan

- [x] All 24 tests in `test_rich_formatting.py` pass on Python 3.11 and 3.12
- [x] Pre-commit hooks (black, isort, flake8, commitizen) pass
- [x] CI passes on staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)