### PR TITLE
Release 3.0.0: Dataset partitioning, Rich formatting, and model improvements

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,18 @@
+name: Commit Lint
+
+on:
+  pull_request:
+    branches: [master, main, staging]
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: pip install commitizen
+      - run: cz check --rev-range origin/${{ github.base_ref }}..HEAD

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,3 +20,8 @@ repos:
     rev: 5.0.3
     hooks:
     -   id: flake8
+-   repo: https://github.com/commitizen-tools/commitizen
+    rev: v3.31.0
+    hooks:
+    -   id: commitizen
+        stages: [commit-msg]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   pipelines
 - Comprehensive test demonstrating QLP-style hierarchical data
   relationships in `test_dataset_relationships.py`
+- **PostgreSQL LIST Partitioning**: DataSet table now uses PostgreSQL LIST
+  partitioning by `observation_id` for efficient query performance at scale
+  (billions of rows, terabytes of data)
+- **Composite Primary Key**: DataSet uses composite primary key
+  `(observation_id, target_id, photometric_method_id, processing_method_id)`
+  for natural partitioning alignment
+- **Sentinel Values**: `PhotometricSource.UNSPECIFIED_ID` and
+  `ProcessingMethod.UNSPECIFIED_ID` (id=0) for "unspecified" records,
+  replacing NULL values in composite key columns
+- **Hybrid Properties**: `DataSet.has_photometric_source` and
+  `DataSet.has_processing_method` for filtering datasets with/without
+  specific sources or methods (works in both Python and SQL queries)
+- **Helper Methods**: `DataSet.add_derived_dataset()` and
+  `DataSet.add_source_dataset()` for managing hierarchy relationships
+- **Sentinel Creation**: `PhotometricSource.get_or_create_unspecified()` and
+  `ProcessingMethod.get_or_create_unspecified()` class methods
 
 ### Changed
 - **BREAKING**: Refactored dataset processing model architecture
@@ -23,8 +39,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in `DataSet`
 - **BREAKING**: Renamed `DetrendingMethod` to `ProcessingMethod` to
   broaden scope beyond detrending
-- DataSet now has separate nullable `photometric_method_id` and
-  `processing_method_id` foreign keys instead of `processing_group_id`
+- **BREAKING**: DataSet no longer has auto-increment `id` column; uses
+  composite primary key instead
+- **BREAKING**: DataSet `photometric_method_id` and `processing_method_id`
+  are now non-nullable (use sentinel value 0 for unspecified)
+- **BREAKING**: DataSetHierarchy uses composite foreign keys (8 columns)
+  instead of simple id references
+- **BREAKING**: PhotometricSource and ProcessingMethod `id` columns are
+  no longer autoincrement; explicit IDs required
+- DataSet hierarchy relationships (`source_datasets`, `derived_datasets`)
+  are now `viewonly=True`; use helper methods to create links
 - Updated model exports in `__init__.py` to reflect new architecture
 
 ### Removed
@@ -32,6 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   relationships instead)
 - **BREAKING**: Removed `DetrendingMethod` model (renamed to
   `ProcessingMethod`)
+- **BREAKING**: Removed DataSet.id auto-increment primary key
 
 ### Migration Guide
 For existing code:
@@ -39,5 +64,27 @@ For existing code:
 - Remove `ProcessingGroup` references
 - Update DataSet queries to use `photometry_source` and
   `processing_method` instead of `processing_group`
-- Database schema migration required to update foreign keys and add
-  `DataSetHierarchy` table
+- Replace `processing_method=None` with
+  `processing_method_id=ProcessingMethod.UNSPECIFIED_ID`
+- Replace `photometry_source=None` with
+  `photometric_method_id=PhotometricSource.UNSPECIFIED_ID`
+- Replace `raw_dataset.derived_datasets.append(derived)` with
+  `raw_dataset.add_derived_dataset(derived, session)`
+- Provide explicit IDs when creating PhotometricSource and ProcessingMethod
+  records (autoincrement is disabled)
+- Database schema migration required:
+  - Add `DataSetHierarchy` table with composite foreign keys
+  - Create sentinel records (id=0) in `photometric_source` and
+    `processing_method` tables
+  - Create PostgreSQL LIST partitions for each observation_id
+
+### Database Administration Notes
+The DataSet table requires partition management:
+```sql
+-- Create partitions for each observation
+CREATE TABLE dataset_obs_1 PARTITION OF dataset FOR VALUES IN (1);
+CREATE TABLE dataset_obs_2 PARTITION OF dataset FOR VALUES IN (2);
+
+-- Default partition for unexpected values
+CREATE TABLE dataset_default PARTITION OF dataset DEFAULT;
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,10 +46,16 @@ docker-compose run test
    - Database entities: Frame, Instrument, Observation, Target, DataSet,
      PhotometricSource, ProcessingMethod
    - DataSetHierarchy: Self-referential model for tracking data lineage
-     and processing provenance
+     and processing provenance (uses composite foreign keys)
    - Uses SQLAlchemy 2.0+ with PostgreSQL backend
    - Models define relationships between astronomical observations and
      their metadata
+   - **DataSet Partitioning**: Uses PostgreSQL LIST partitioning by
+     `observation_id` for scale (billions of rows)
+   - **Composite Primary Key**: DataSet uses composite PK
+     `(observation_id, target_id, photometric_method_id, processing_method_id)`
+   - **Sentinel Values**: PhotometricSource and ProcessingMethod use id=0
+     for "unspecified" (no NULLs in composite key)
 
 2. **Database Connection** (`src/lightcurvedb/core/`)
    - Configuration via `~/.config/lightcurvedb/db.conf`
@@ -79,12 +85,17 @@ Recent refactoring has removed:
 - Manager classes (`src/lightcurvedb/managers/`)
 - Ingestor functionality
 
-Recent feature additions (feature/dataset-hierarchy branch):
+Recent feature additions (feature/dataset-partitioning branch):
 - Dataset hierarchy system for tracking data lineage
 - Refactored processing model: replaced ProcessingGroup with direct
   relationships
 - Renamed DetrendingMethod to ProcessingMethod for broader scope
 - DataSet now supports source_datasets and derived_datasets relationships
+- **PostgreSQL LIST partitioning** by observation_id for scale
+- **Composite primary key** replacing auto-increment id
+- **Sentinel values** (id=0) for unspecified photometric/processing methods
+- Helper methods for managing dataset hierarchy (add_derived_dataset,
+  add_source_dataset)
 
 The project uses property-based testing with Hypothesis and includes
 extensive TESS test data including FITS files and ephemeris data from

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,6 @@
-FROM thekevjames/nox
-
-COPY docker_runner /root/.ssh/id_rsa
-COPY tests/ssh-config /root/ssh/config
-
-RUN touch /root/.ssh/known_hosts && ssh-keyscan tessgit.mit.edu >> /root/.ssh/known_hosts
+FROM acidrain/multi-python
 
 RUN apt-get update && apt-get install -y postgresql libpq-dev
+RUN pip install nox
+
 CMD ["tail", "-f", "/dev/null"]

--- a/docs/source/schema.rst
+++ b/docs/source/schema.rst
@@ -11,9 +11,25 @@ The database schema consists of several interconnected model groups:
 1. **Mission Hierarchy**: Mission → MissionCatalog → Target
 2. **Instrument Hierarchy**: Self-referential instrument tree
 3. **Observation System**: Polymorphic observation models with FITS frame support
-4. **Processing Pipeline**: PhotometricSource and ProcessingMethod
+4. **Processing Pipeline**: PhotometricSource and ProcessingMethod (with sentinel values for "unspecified")
 5. **Data Products**: DataSet (lightcurves), TargetSpecificTime, and QualityFlagArray
-6. **Data Lineage**: DataSetHierarchy for tracking processing provenance
+6. **Data Lineage**: DataSetHierarchy for tracking processing provenance (composite foreign keys)
+
+**Key Design Features**:
+
+- **DataSet Partitioning**: The DataSet table uses PostgreSQL LIST partitioning by
+  ``observation_id`` for efficient query performance at scale (billions of rows,
+  terabytes of array data). Each observation becomes its own partition containing
+  millions of rows.
+
+- **Composite Primary Key**: DataSet uses a composite primary key
+  ``(observation_id, target_id, photometric_method_id, processing_method_id)``
+  instead of an auto-increment ID, aligning with the partition key for optimal
+  performance.
+
+- **Sentinel Values**: PhotometricSource and ProcessingMethod use ``id=0`` as a
+  sentinel value for "unspecified", allowing non-nullable foreign keys in the
+  composite primary key while preserving semantic meaning.
 
 Entity Relationship Diagram
 ---------------------------
@@ -106,31 +122,35 @@ Entity Relationship Diagram
        }
 
        PhotometricSource {
-           int id PK
+           int id PK "0=unspecified sentinel"
            string name UK
            string description
        }
 
        ProcessingMethod {
-           int id PK
+           int id PK "0=unspecified sentinel"
            string name UK
            string description
        }
 
        DataSet {
-           int id PK
-           int target_id FK
-           int observation_id FK
-           int photometric_method_id FK "nullable"
-           int processing_method_id FK "nullable"
+           int observation_id PK-FK "partition key"
+           int target_id PK-FK
+           int photometric_method_id PK-FK "0=unspecified"
+           int processing_method_id PK-FK "0=unspecified"
            array values
            array errors
        }
 
        DataSetHierarchy {
-           int id PK
-           int source_dataset_id FK
-           int child_dataset_id FK
+           int source_observation_id PK-FK
+           int source_target_id PK-FK
+           int source_photometric_method_id PK-FK
+           int source_processing_method_id PK-FK
+           int child_observation_id PK-FK
+           int child_target_id PK-FK
+           int child_photometric_method_id PK-FK
+           int child_processing_method_id PK-FK
        }
 
        TargetSpecificTime {
@@ -370,7 +390,7 @@ Querying for a target's lightcurves:
 
 .. code-block:: python
 
-   from lightcurvedb.models import Target, DataSet
+   from lightcurvedb.models import Target, DataSet, ProcessingMethod
 
    # Get all lightcurves for a specific TIC ID
    target = session.query(Target).filter_by(name=12345678).first()
@@ -378,10 +398,16 @@ Querying for a target's lightcurves:
 
    # Get lightcurves with specific processing
    for lc in lightcurves:
-       photometry = lc.photometry_source.name if lc.photometry_source else "N/A"
-       processing = lc.processing_method.name if lc.processing_method else "Raw"
+       photometry = lc.photometry_source.name if lc.has_photometric_source else "N/A"
+       processing = lc.processing_method.name if lc.has_processing_method else "Raw"
        print(f"Photometry: {photometry}, Processing: {processing}")
        print(f"Values: {lc.values}")
+
+   # Query raw datasets (no processing method specified)
+   raw_lightcurves = session.query(DataSet).filter(
+       DataSet.target_id == target.id,
+       DataSet.has_processing_method == False
+   ).all()
 
 Creating instrument hierarchy:
 
@@ -428,16 +454,16 @@ Tracking data lineage with dataset hierarchy:
 
 .. code-block:: python
 
-   from lightcurvedb.models import DataSet
+   from lightcurvedb.models import DataSet, ProcessingMethod
    import numpy as np
 
-   # Create raw photometry dataset
+   # Create raw photometry dataset (using sentinel for unspecified processing)
    raw_flux = np.random.normal(1.0, 0.01, 1000)
    raw_dataset = DataSet(
        target=target,
        observation=observation,
        photometry_source=aperture_source,
-       processing_method=None,  # Raw data, no processing
+       processing_method_id=ProcessingMethod.UNSPECIFIED_ID,  # Sentinel value
        values=raw_flux
    )
    session.add(raw_dataset)
@@ -452,22 +478,35 @@ Tracking data lineage with dataset hierarchy:
        processing_method=detrending_method,
        values=detrended_flux
    )
-
-   # Establish hierarchical relationship
-   detrended_dataset.source_datasets.append(raw_dataset)
    session.add(detrended_dataset)
+   session.flush()
+
+   # Establish hierarchical relationship using helper method
+   raw_dataset.add_derived_dataset(detrended_dataset, session)
    session.commit()
 
    # Query the hierarchy
    print(f"Raw dataset has {len(raw_dataset.derived_datasets)} derived products")
    print(f"Detrended dataset has {len(detrended_dataset.source_datasets)} sources")
 
+   # Filter using hybrid properties
+   raw_datasets = session.query(DataSet).filter(
+       DataSet.has_processing_method == False
+   ).all()
+
 Database Constraints
 --------------------
 
 The schema enforces several important constraints:
 
-1. **Unique Constraints**:
+1. **Primary Keys**:
+
+   - Most tables use auto-increment integer or UUID primary keys
+   - **DataSet**: Composite primary key ``(observation_id, target_id, photometric_method_id, processing_method_id)``
+   - **DataSetHierarchy**: Composite primary key of all 8 foreign key columns
+   - **PhotometricSource/ProcessingMethod**: Non-autoincrement ID (explicit IDs required; id=0 reserved for sentinel)
+
+2. **Unique Constraints**:
 
    - Mission.name must be unique
    - MissionCatalog.name must be unique
@@ -477,15 +516,22 @@ The schema enforces several important constraints:
    - FITSFrame: (type, cadence) combination must be unique
    - QualityFlagArray: (type, observation_id, target_id) must be unique (with NULL handling)
 
-2. **Cascade Deletes**:
+3. **Cascade Deletes**:
 
    - Deleting an Observation cascades to FITSFrame, TargetSpecificTime, DataSet, and QualityFlagArray
-   - Deleting a PhotometricSource or ProcessingMethod cascades to DataSet
    - Deleting a Target cascades to DataSet
    - Deleting a DataSet cascades to DataSetHierarchy entries
+   - PhotometricSource/ProcessingMethod use RESTRICT (cannot delete if DataSets reference them)
 
-3. **Referential Integrity**:
+4. **Referential Integrity**:
 
    - All foreign keys are enforced at the database level
    - Orphaned records are prevented through proper relationships
-   - DataSetHierarchy maintains referential integrity for lineage tracking
+   - DataSetHierarchy maintains referential integrity via composite foreign keys
+   - Sentinel records (id=0) must exist before creating DataSets
+
+5. **Partitioning**:
+
+   - DataSet table is partitioned by LIST on ``observation_id``
+   - Partitions must be created by DBA before inserting data for new observations
+   - A default partition handles unexpected observation IDs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "packaging>=23.2",
     "tabulate>=0.9.0",
     "kavli-configurables",
+    "rich>=13",
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ where = ["src"]
 
 [project]
 name = "lightcurvedb"
-version = "3.0.0-beta.5"  # Managed by python-semantic-release
+version = "3.0.0-beta.6"  # Managed by python-semantic-release
 description = "SQLAlchemy models and APIs for storing lightcurve timeseries."
 authors = [{name="William Fong", email="willfong@mit.edu"}]
 readme = "README.rst"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,3 +136,4 @@ exclude_lines = [
 name = "cz_conventional_commits"
 tag_format = "v$version"
 allowed_types = ["build", "chore", "ci", "docs", "feat", "fix", "perf", "refactor", "style", "test"]
+allowed_prefixes = ["Merge", "Revert", "Pull request", "fixup!", "squash!", "amend!", "0.", "1.", "2.", "3.", "4.", "5.", "6.", "7.", "8.", "9."]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ where = ["src"]
 
 [project]
 name = "lightcurvedb"
-version = "3.0.0-beta.3"  # Managed by python-semantic-release
+version = "3.0.0-beta.4"  # Managed by python-semantic-release
 description = "SQLAlchemy models and APIs for storing lightcurve timeseries."
 authors = [{name="William Fong", email="willfong@mit.edu"}]
 readme = "README.rst"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ where = ["src"]
 
 [project]
 name = "lightcurvedb"
-version = "3.0.0-beta.2"  # Managed by python-semantic-release
+version = "3.0.0-beta.3"  # Managed by python-semantic-release
 description = "SQLAlchemy models and APIs for storing lightcurve timeseries."
 authors = [{name="William Fong", email="willfong@mit.edu"}]
 readme = "README.rst"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,8 @@ dev = [
     "pytest>=8.2",
     "pytest_postgresql",
     "pytest-timeout",
-    "nox"
+    "nox",
+    "commitizen>=3.0.0",
 ]
 
 docs = [
@@ -129,3 +130,8 @@ exclude_lines = [
     "if TYPE_CHECKING:",
     "if typing.TYPE_CHECKING:",
 ]
+
+[tool.commitizen]
+name = "cz_conventional_commits"
+tag_format = "v$version"
+allowed_types = ["build", "chore", "ci", "docs", "feat", "fix", "perf", "refactor", "style", "test"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ where = ["src"]
 
 [project]
 name = "lightcurvedb"
-version = "2.3.0-beta.2"  # Managed by python-semantic-release
+version = "3.0.0-beta.1"  # Managed by python-semantic-release
 description = "SQLAlchemy models and APIs for storing lightcurve timeseries."
 authors = [{name="William Fong", email="willfong@mit.edu"}]
 readme = "README.rst"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ where = ["src"]
 
 [project]
 name = "lightcurvedb"
-version = "3.0.0-beta.1"  # Managed by python-semantic-release
+version = "3.0.0-beta.2"  # Managed by python-semantic-release
 description = "SQLAlchemy models and APIs for storing lightcurve timeseries."
 authors = [{name="William Fong", email="willfong@mit.edu"}]
 readme = "README.rst"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ where = ["src"]
 
 [project]
 name = "lightcurvedb"
-version = "3.0.0-beta.4"  # Managed by python-semantic-release
+version = "3.0.0-beta.5"  # Managed by python-semantic-release
 description = "SQLAlchemy models and APIs for storing lightcurve timeseries."
 authors = [{name="William Fong", email="willfong@mit.edu"}]
 readme = "README.rst"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ where = ["src"]
 
 [project]
 name = "lightcurvedb"
-version = "3.0.0-beta.6"  # Managed by python-semantic-release
+version = "3.0.0-beta.7"  # Managed by python-semantic-release
 description = "SQLAlchemy models and APIs for storing lightcurve timeseries."
 authors = [{name="William Fong", email="willfong@mit.edu"}]
 readme = "README.rst"

--- a/src/lightcurvedb/__init__.py
+++ b/src/lightcurvedb/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.0.0-beta.4"  # Managed by python-semantic-release
+__version__ = "3.0.0-beta.5"  # Managed by python-semantic-release
 
 from lightcurvedb.core.connection import LCDB_Session, db, db_from_config
 

--- a/src/lightcurvedb/__init__.py
+++ b/src/lightcurvedb/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.0.0-beta.1"  # Managed by python-semantic-release
+__version__ = "3.0.0-beta.2"  # Managed by python-semantic-release
 
 from lightcurvedb.core.connection import LCDB_Session, db, db_from_config
 

--- a/src/lightcurvedb/__init__.py
+++ b/src/lightcurvedb/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.0.0-beta.6"  # Managed by python-semantic-release
+__version__ = "3.0.0-beta.7"  # Managed by python-semantic-release
 
 from lightcurvedb.core.connection import LCDB_Session, db, db_from_config
 

--- a/src/lightcurvedb/__init__.py
+++ b/src/lightcurvedb/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.0.0-beta.5"  # Managed by python-semantic-release
+__version__ = "3.0.0-beta.6"  # Managed by python-semantic-release
 
 from lightcurvedb.core.connection import LCDB_Session, db, db_from_config
 

--- a/src/lightcurvedb/__init__.py
+++ b/src/lightcurvedb/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.0.0-beta.2"  # Managed by python-semantic-release
+__version__ = "3.0.0-beta.3"  # Managed by python-semantic-release
 
 from lightcurvedb.core.connection import LCDB_Session, db, db_from_config
 

--- a/src/lightcurvedb/__init__.py
+++ b/src/lightcurvedb/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.0.0-beta.3"  # Managed by python-semantic-release
+__version__ = "3.0.0-beta.4"  # Managed by python-semantic-release
 
 from lightcurvedb.core.connection import LCDB_Session, db, db_from_config
 

--- a/src/lightcurvedb/__init__.py
+++ b/src/lightcurvedb/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.3.0-beta.2"  # Managed by python-semantic-release
+__version__ = "3.0.0-beta.1"  # Managed by python-semantic-release
 
 from lightcurvedb.core.connection import LCDB_Session, db, db_from_config
 

--- a/src/lightcurvedb/core/base_model.py
+++ b/src/lightcurvedb/core/base_model.py
@@ -12,6 +12,18 @@ from sqlalchemy.dialects.postgresql import JSONB
 from lightcurvedb.core.types import NumpyArrayType
 
 
+def _format_array_summary(arr) -> str:
+    """Format a numpy array as a compact summary string."""
+    if arr is None:
+        return "None"
+    if not isinstance(arr, np.ndarray):
+        return repr(arr)
+    if len(arr) <= 6:
+        return repr(arr.tolist())
+    dtype = arr.dtype
+    return f"{dtype}[{len(arr)}] range=[{arr.min()}, {arr.max()}]"
+
+
 class LCDBModel(orm.DeclarativeBase):
     """
     A common SQLAlchemy base model for LCDB v2 models.
@@ -41,6 +53,28 @@ class LCDBModel(orm.DeclarativeBase):
             f"{col}={getattr(self, col, '?')!r}" for col in pk_cols
         )
         return f"<{self.__class__.__name__}({pk_values})>"
+
+    def __rich_repr__(self):
+        mapper = sa.inspect(self.__class__)
+        pk_cols = [col.name for col in mapper.primary_key]
+        for col in pk_cols:
+            yield col, getattr(self, col, None)
+
+    def __rich_console__(self, console, options):
+        from rich.table import Table
+
+        table = Table(title=self.__class__.__name__, show_header=True)
+        table.add_column("Field", style="bold cyan")
+        table.add_column("Value")
+        mapper = sa.inspect(self.__class__)
+        for col in mapper.columns:
+            val = getattr(self, col.key, None)
+            if isinstance(val, np.ndarray):
+                display = _format_array_summary(val)
+            else:
+                display = repr(val)
+            table.add_row(col.key, display)
+        yield table
 
 
 @orm.declarative_mixin

--- a/src/lightcurvedb/core/base_model.py
+++ b/src/lightcurvedb/core/base_model.py
@@ -33,6 +33,15 @@ class LCDBModel(orm.DeclarativeBase):
         pathlib.Path: sa.String,
     }
 
+    def __repr__(self) -> str:
+        """Default repr for LCDB models. Shows class name and primary keys."""
+        mapper = sa.inspect(self.__class__)
+        pk_cols = [col.name for col in mapper.primary_key]
+        pk_values = ", ".join(
+            f"{col}={getattr(self, col, '?')!r}" for col in pk_cols
+        )
+        return f"<{self.__class__.__name__}({pk_values})>"
+
 
 @orm.declarative_mixin
 class CreatedOnMixin:

--- a/src/lightcurvedb/models/dataset.py
+++ b/src/lightcurvedb/models/dataset.py
@@ -84,6 +84,9 @@ class PhotometricSource(LCDBModel, NameAndDescriptionMixin):
             session.flush()
         return sentinel
 
+    def __repr__(self) -> str:
+        return f"<PhotometricSource(id={self.id!r}, name={self.name!r})>"
+
 
 class ProcessingMethod(LCDBModel, NameAndDescriptionMixin):
     """
@@ -152,6 +155,9 @@ class ProcessingMethod(LCDBModel, NameAndDescriptionMixin):
             session.add(sentinel)
             session.flush()
         return sentinel
+
+    def __repr__(self) -> str:
+        return f"<ProcessingMethod(id={self.id!r}, name={self.name!r})>"
 
 
 class DataSetHierarchy(LCDBModel):
@@ -275,6 +281,15 @@ class DataSetHierarchy(LCDBModel):
     child_processing_method_id: orm.Mapped[int] = orm.mapped_column(
         nullable=False
     )
+
+    def __repr__(self) -> str:
+        return (
+            f"<DataSetHierarchy("
+            f"source=(obs={self.source_observation_id}, "
+            f"target={self.source_target_id}) -> "
+            f"child=(obs={self.child_observation_id}, "
+            f"target={self.child_target_id}))>"
+        )
 
 
 class DataSet(LCDBModel):
@@ -636,3 +651,10 @@ class DataSet(LCDBModel):
                 self.errors,
                 fill_value=fill_value,
             )
+
+    def __repr__(self) -> str:
+        return (
+            f"<DataSet(obs={self.observation_id}, target={self.target_id}, "
+            f"phot={self.photometric_method_id}, "
+            f"proc={self.processing_method_id})>"
+        )

--- a/src/lightcurvedb/models/dataset.py
+++ b/src/lightcurvedb/models/dataset.py
@@ -1,10 +1,11 @@
 import typing
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 import numpy as np
 import sqlalchemy as sa
 from numpy import typing as npt
 from sqlalchemy import orm
+from sqlalchemy.ext.hybrid import hybrid_property
 
 from lightcurvedb.core.base_model import LCDBModel, NameAndDescriptionMixin
 
@@ -21,10 +22,13 @@ class PhotometricSource(LCDBModel, NameAndDescriptionMixin):
     data from observations, such as aperture photometry with different
     aperture sizes or PSF photometry.
 
+    The sentinel record with id=0 represents "unspecified" photometric source
+    for datasets where the source is not applicable or unknown.
+
     Attributes
     ----------
     id : int
-        Primary key identifier
+        Primary key identifier (0 = unspecified sentinel)
     name : str
         Name of the photometric method (inherited from mixin)
     description : str
@@ -40,9 +44,45 @@ class PhotometricSource(LCDBModel, NameAndDescriptionMixin):
 
     __tablename__ = "photometric_source"
 
-    id: orm.Mapped[int] = orm.mapped_column(primary_key=True)
+    UNSPECIFIED_ID: ClassVar[int] = 0
 
-    datasets: orm.Mapped[list["DataSet"]] = orm.relationship(lazy=True)
+    id: orm.Mapped[int] = orm.mapped_column(
+        primary_key=True,
+        autoincrement=False,
+    )
+
+    datasets: orm.Mapped[list["DataSet"]] = orm.relationship(
+        lazy=True,
+        back_populates="photometry_source",
+    )
+
+    @classmethod
+    def get_or_create_unspecified(
+        cls, session: orm.Session
+    ) -> "PhotometricSource":
+        """
+        Get or create the unspecified sentinel record.
+
+        Parameters
+        ----------
+        session : orm.Session
+            Active database session.
+
+        Returns
+        -------
+        PhotometricSource
+            The sentinel record with id=0.
+        """
+        sentinel = session.get(cls, cls.UNSPECIFIED_ID)
+        if sentinel is None:
+            sentinel = cls(
+                id=cls.UNSPECIFIED_ID,
+                name="Unspecified",
+                description="No photometric source specified",
+            )
+            session.add(sentinel)
+            session.flush()
+        return sentinel
 
 
 class ProcessingMethod(LCDBModel, NameAndDescriptionMixin):
@@ -53,14 +93,18 @@ class ProcessingMethod(LCDBModel, NameAndDescriptionMixin):
     These modules should describe some complete unit of work/operation
     performed on a dataset such detrending or 'original' sources of data.
 
+    The sentinel record with id=0 represents "unspecified" processing method
+    for raw datasets where no processing has been applied.
+
     Attributes
     ----------
     id : int
-        Primary key identifier
+        Primary key identifier (0 = unspecified sentinel)
     name : str
         Name of the detrending method (inherited from mixin)
     description : str
         Detailed description (inherited from mixin)
+
     Examples
     --------
     >>> pdc = ProcessingMethod(name="PDC-SAP",
@@ -69,15 +113,51 @@ class ProcessingMethod(LCDBModel, NameAndDescriptionMixin):
 
     __tablename__ = "processing_method"
 
-    id: orm.Mapped[int] = orm.mapped_column(primary_key=True)
+    UNSPECIFIED_ID: ClassVar[int] = 0
 
-    datasets: orm.Mapped[list["DataSet"]] = orm.relationship(lazy=True)
+    id: orm.Mapped[int] = orm.mapped_column(
+        primary_key=True,
+        autoincrement=False,
+    )
+
+    datasets: orm.Mapped[list["DataSet"]] = orm.relationship(
+        lazy=True,
+        back_populates="processing_method",
+    )
+
+    @classmethod
+    def get_or_create_unspecified(
+        cls, session: orm.Session
+    ) -> "ProcessingMethod":
+        """
+        Get or create the unspecified sentinel record.
+
+        Parameters
+        ----------
+        session : orm.Session
+            Active database session.
+
+        Returns
+        -------
+        ProcessingMethod
+            The sentinel record with id=0.
+        """
+        sentinel = session.get(cls, cls.UNSPECIFIED_ID)
+        if sentinel is None:
+            sentinel = cls(
+                id=cls.UNSPECIFIED_ID,
+                name="Unspecified",
+                description="No processing method applied (raw data)",
+            )
+            session.add(sentinel)
+            session.flush()
+        return sentinel
 
 
 class DataSetHierarchy(LCDBModel):
     """
     Association table for creating hierarchical relationships between
-    DataSets.
+    DataSets using composite foreign keys.
 
     This table enables a tree structure where datasets can be derived from
     other datasets, allowing tracking of data processing lineage and
@@ -86,27 +166,114 @@ class DataSetHierarchy(LCDBModel):
 
     Attributes
     ----------
-    source_dataset_id : int
-        Foreign key to the parent/source dataset
-    child_dataset_id : int
-        Foreign key to the child/derived dataset
+    source_observation_id : int
+        Observation ID of the parent/source dataset
+    source_target_id : int
+        Target ID of the parent/source dataset
+    source_photometric_method_id : int
+        Photometric method ID of the parent/source dataset
+    source_processing_method_id : int
+        Processing method ID of the parent/source dataset
+    child_observation_id : int
+        Observation ID of the child/derived dataset
+    child_target_id : int
+        Target ID of the child/derived dataset
+    child_photometric_method_id : int
+        Photometric method ID of the child/derived dataset
+    child_processing_method_id : int
+        Processing method ID of the child/derived dataset
 
     Notes
     -----
     This is an association table for a many-to-many self-referential
-    relationship. A dataset can have multiple parents (e.g., combining
-    data from multiple sources) and multiple children (e.g., different
-    processing methods applied to the same source).
+    relationship using composite keys. A dataset can have multiple parents
+    (e.g., combining data from multiple sources) and multiple children
+    (e.g., different processing methods applied to the same source).
+
+    The composite primary key consists of all 8 columns to ensure unique
+    source-child relationships.
     """
 
     __tablename__ = "datasethierarchy"
 
-    id: orm.Mapped[int] = orm.mapped_column(primary_key=True)
-    source_dataset_id: orm.Mapped[int] = orm.mapped_column(
-        sa.ForeignKey("dataset.id", ondelete="CASCADE"), index=True
+    __table_args__ = (
+        sa.PrimaryKeyConstraint(
+            "source_observation_id",
+            "source_target_id",
+            "source_photometric_method_id",
+            "source_processing_method_id",
+            "child_observation_id",
+            "child_target_id",
+            "child_photometric_method_id",
+            "child_processing_method_id",
+            name="pk_datasethierarchy",
+        ),
+        sa.ForeignKeyConstraint(
+            [
+                "source_observation_id",
+                "source_target_id",
+                "source_photometric_method_id",
+                "source_processing_method_id",
+            ],
+            [
+                "dataset.observation_id",
+                "dataset.target_id",
+                "dataset.photometric_method_id",
+                "dataset.processing_method_id",
+            ],
+            name="fk_datasethierarchy_source",
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            [
+                "child_observation_id",
+                "child_target_id",
+                "child_photometric_method_id",
+                "child_processing_method_id",
+            ],
+            [
+                "dataset.observation_id",
+                "dataset.target_id",
+                "dataset.photometric_method_id",
+                "dataset.processing_method_id",
+            ],
+            name="fk_datasethierarchy_child",
+            ondelete="CASCADE",
+        ),
+        sa.Index(
+            "ix_datasethierarchy_source",
+            "source_observation_id",
+            "source_target_id",
+            "source_photometric_method_id",
+            "source_processing_method_id",
+        ),
+        sa.Index(
+            "ix_datasethierarchy_child",
+            "child_observation_id",
+            "child_target_id",
+            "child_photometric_method_id",
+            "child_processing_method_id",
+        ),
     )
-    child_dataset_id: orm.Mapped[int] = orm.mapped_column(
-        sa.ForeignKey("dataset.id", ondelete="CASCADE"), index=True
+
+    # Source dataset composite key columns
+    source_observation_id: orm.Mapped[int] = orm.mapped_column(nullable=False)
+    source_target_id: orm.Mapped[int] = orm.mapped_column(nullable=False)
+    source_photometric_method_id: orm.Mapped[int] = orm.mapped_column(
+        nullable=False
+    )
+    source_processing_method_id: orm.Mapped[int] = orm.mapped_column(
+        nullable=False
+    )
+
+    # Child dataset composite key columns
+    child_observation_id: orm.Mapped[int] = orm.mapped_column(nullable=False)
+    child_target_id: orm.Mapped[int] = orm.mapped_column(nullable=False)
+    child_photometric_method_id: orm.Mapped[int] = orm.mapped_column(
+        nullable=False
+    )
+    child_processing_method_id: orm.Mapped[int] = orm.mapped_column(
+        nullable=False
     )
 
 
@@ -114,24 +281,28 @@ class DataSet(LCDBModel):
     """
     A processed lightcurve for a specific target and observation.
 
-    DataSet is the central model that connects a target, an
-    observation, and a processing method to produce a final lightcurve.
-    It stores the actual photometric measurements and uncertainties.
+    DataSet is the central model that connects a target, an observation,
+    and a processing method to produce a final lightcurve. It stores the
+    actual photometric measurements and uncertainties.
+
+    The composite primary key (observation_id, target_id,
+    photometric_method_id, processing_method_id) uniquely identifies each
+    dataset. The table is
+    partitioned by observation_id using PostgreSQL LIST partitioning for
+    efficient query performance at scale.
 
     Attributes
     ----------
-    id : int
-        Primary key identifier
-    target_id : int
-        Foreign key to target
     observation_id : int
-        Foreign key to observation
-    photometric_method_id : int, optional
-        Foreign key to photometric source. Nullable to allow datasets
-        without explicit photometry method (e.g., derived products).
-    processing_method_id : int, optional
-        Foreign key to processing method. Nullable to allow raw photometry
-        datasets without processing applied.
+        Foreign key to observation (part of composite PK, partition key)
+    target_id : int
+        Foreign key to target (part of composite PK)
+    photometric_method_id : int
+        Foreign key to photometric source (part of composite PK).
+        Use PhotometricSource.UNSPECIFIED_ID (0) for unspecified.
+    processing_method_id : int
+        Foreign key to processing method (part of composite PK).
+        Use ProcessingMethod.UNSPECIFIED_ID (0) for unspecified.
     values : ndarray[float64]
         Array of photometric measurements (flux or magnitude)
     errors : ndarray[float64], optional
@@ -153,46 +324,76 @@ class DataSet(LCDBModel):
 
     Notes
     -----
-    This is the main table for storing lightcurve data. Each row
-    represents one complete lightcurve for a target processed
-    with a specific method.
+    This is the main table for storing lightcurve data. Each row represents
+    one complete lightcurve for a target processed with a specific method.
+
+    The table uses PostgreSQL LIST partitioning by observation_id, with each
+    observation containing millions of rows as a natural partition boundary.
+    Partitions are managed by database administrators.
 
     The hierarchical relationships (source_datasets, derived_datasets) enable
-    tracking data processing lineage. For example, a detrended lightcurve
-    would list the raw photometry dataset in source_datasets, while the raw
-    dataset would list all derived products in derived_datasets.
+    tracking data processing lineage. These relationships are read-only; use
+    the add_derived_dataset() and add_source_dataset() helper methods to
+    create hierarchy links.
 
     Examples
     --------
     >>> # Create a hierarchical relationship
-    >>> raw_dataset = DataSet(target=target, observation=obs, values=raw_flux)
-    >>> detrended_dataset = DataSet(target=target, observation=obs,
-    ...                             values=detrended_flux)
-    >>> detrended_dataset.source_datasets.append(raw_dataset)
+    >>> raw_dataset = DataSet(
+    ...     target=target,
+    ...     observation=obs,
+    ...     values=raw_flux,
+    ...     photometric_method_id=source.id,
+    ...     processing_method_id=ProcessingMethod.UNSPECIFIED_ID,
+    ... )
+    >>> detrended_dataset = DataSet(
+    ...     target=target,
+    ...     observation=obs,
+    ...     values=detrended_flux,
+    ...     photometric_method_id=source.id,
+    ...     processing_method_id=detrend_method.id,
+    ... )
     >>> session.add_all([raw_dataset, detrended_dataset])
+    >>> session.flush()
+    >>> raw_dataset.add_derived_dataset(detrended_dataset, session)
     >>> session.commit()
     """
 
     __tablename__ = "dataset"
 
-    id: orm.Mapped[int] = orm.mapped_column(primary_key=True)
-    target_id: orm.Mapped[int] = orm.mapped_column(
-        sa.ForeignKey("target.id", ondelete="CASCADE"), index=True
-    )
-    observation_id: orm.Mapped[int] = orm.mapped_column(
-        sa.ForeignKey("observation.id", ondelete="CASCADE"), index=True
-    )
-    photometric_method_id: orm.Mapped[int] = orm.mapped_column(
-        sa.ForeignKey("photometric_source.id", ondelete="CASCADE"),
-        index=True,
-        nullable=True,
-    )
-    processing_method_id: orm.Mapped[int] = orm.mapped_column(
-        sa.ForeignKey("processing_method.id", ondelete="CASCADE"),
-        index=True,
-        nullable=True,
+    __table_args__ = (
+        sa.PrimaryKeyConstraint(
+            "observation_id",
+            "target_id",
+            "photometric_method_id",
+            "processing_method_id",
+            name="pk_dataset",
+        ),
+        {"postgresql_partition_by": "LIST (observation_id)"},
     )
 
+    # Composite PK columns (observation_id first for partitioning)
+    observation_id: orm.Mapped[int] = orm.mapped_column(
+        sa.ForeignKey("observation.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    target_id: orm.Mapped[int] = orm.mapped_column(
+        sa.ForeignKey("target.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    photometric_method_id: orm.Mapped[int] = orm.mapped_column(
+        sa.ForeignKey("photometric_source.id", ondelete="RESTRICT"),
+        nullable=False,
+        default=0,
+    )
+    processing_method_id: orm.Mapped[int] = orm.mapped_column(
+        sa.ForeignKey("processing_method.id", ondelete="RESTRICT"),
+        nullable=False,
+        default=0,
+    )
+
+    # Data columns
     values: orm.Mapped[npt.NDArray[np.float64]]
     errors: orm.Mapped[typing.Optional[npt.NDArray[np.float64]]]
 
@@ -202,28 +403,147 @@ class DataSet(LCDBModel):
         back_populates="datasets"
     )
     photometry_source: orm.Mapped["PhotometricSource"] = orm.relationship(
-        back_populates="datasets"
+        back_populates="datasets",
+        foreign_keys=[photometric_method_id],
     )
     processing_method: orm.Mapped["ProcessingMethod"] = orm.relationship(
-        back_populates="datasets"
+        back_populates="datasets",
+        foreign_keys=[processing_method_id],
     )
 
-    # Self-referential hierarchical relationships
+    # Self-referential hierarchical relationships (viewonly due to composite)
     source_datasets: orm.Mapped[list["DataSet"]] = orm.relationship(
         "DataSet",
         secondary="datasethierarchy",
-        primaryjoin="DataSet.id == DataSetHierarchy.child_dataset_id",
-        secondaryjoin="DataSet.id == DataSetHierarchy.source_dataset_id",
+        primaryjoin=(
+            "and_("
+            "DataSet.observation_id == "
+            "DataSetHierarchy.child_observation_id, "
+            "DataSet.target_id == DataSetHierarchy.child_target_id, "
+            "DataSet.photometric_method_id == "
+            "DataSetHierarchy.child_photometric_method_id, "
+            "DataSet.processing_method_id == "
+            "DataSetHierarchy.child_processing_method_id"
+            ")"
+        ),
+        secondaryjoin=(
+            "and_("
+            "DataSet.observation_id == "
+            "DataSetHierarchy.source_observation_id, "
+            "DataSet.target_id == DataSetHierarchy.source_target_id, "
+            "DataSet.photometric_method_id == "
+            "DataSetHierarchy.source_photometric_method_id, "
+            "DataSet.processing_method_id == "
+            "DataSetHierarchy.source_processing_method_id"
+            ")"
+        ),
         back_populates="derived_datasets",
+        viewonly=True,
     )
 
     derived_datasets: orm.Mapped[list["DataSet"]] = orm.relationship(
         "DataSet",
         secondary="datasethierarchy",
-        primaryjoin="DataSet.id == DataSetHierarchy.source_dataset_id",
-        secondaryjoin="DataSet.id == DataSetHierarchy.child_dataset_id",
+        primaryjoin=(
+            "and_("
+            "DataSet.observation_id == "
+            "DataSetHierarchy.source_observation_id, "
+            "DataSet.target_id == DataSetHierarchy.source_target_id, "
+            "DataSet.photometric_method_id == "
+            "DataSetHierarchy.source_photometric_method_id, "
+            "DataSet.processing_method_id == "
+            "DataSetHierarchy.source_processing_method_id"
+            ")"
+        ),
+        secondaryjoin=(
+            "and_("
+            "DataSet.observation_id == "
+            "DataSetHierarchy.child_observation_id, "
+            "DataSet.target_id == DataSetHierarchy.child_target_id, "
+            "DataSet.photometric_method_id == "
+            "DataSetHierarchy.child_photometric_method_id, "
+            "DataSet.processing_method_id == "
+            "DataSetHierarchy.child_processing_method_id"
+            ")"
+        ),
         back_populates="source_datasets",
+        viewonly=True,
     )
+
+    @hybrid_property
+    def has_photometric_source(self) -> bool:
+        """Return True if a specific photometric source is set."""
+        return self.photometric_method_id != PhotometricSource.UNSPECIFIED_ID
+
+    @has_photometric_source.expression
+    def has_photometric_source(cls):
+        """SQL expression for filtering datasets with photometric source."""
+        return cls.photometric_method_id != PhotometricSource.UNSPECIFIED_ID
+
+    @hybrid_property
+    def has_processing_method(self) -> bool:
+        """Return True if a specific processing method is set."""
+        return self.processing_method_id != ProcessingMethod.UNSPECIFIED_ID
+
+    @has_processing_method.expression
+    def has_processing_method(cls):
+        """SQL expression for filtering datasets with processing method."""
+        return cls.processing_method_id != ProcessingMethod.UNSPECIFIED_ID
+
+    def add_derived_dataset(
+        self,
+        derived: "DataSet",
+        session: orm.Session,
+    ) -> DataSetHierarchy:
+        """
+        Create a hierarchy link from this dataset to a derived dataset.
+
+        Parameters
+        ----------
+        derived : DataSet
+            The child dataset derived from this one.
+        session : orm.Session
+            Active database session.
+
+        Returns
+        -------
+        DataSetHierarchy
+            The created hierarchy record.
+        """
+        hierarchy = DataSetHierarchy(
+            source_observation_id=self.observation_id,
+            source_target_id=self.target_id,
+            source_photometric_method_id=self.photometric_method_id,
+            source_processing_method_id=self.processing_method_id,
+            child_observation_id=derived.observation_id,
+            child_target_id=derived.target_id,
+            child_photometric_method_id=derived.photometric_method_id,
+            child_processing_method_id=derived.processing_method_id,
+        )
+        session.add(hierarchy)
+        return hierarchy
+
+    def add_source_dataset(
+        self,
+        source: "DataSet",
+        session: orm.Session,
+    ) -> DataSetHierarchy:
+        """
+        Create a hierarchy link from a source dataset to this dataset.
+
+        Parameters
+        ----------
+        source : DataSet
+            The parent dataset this one is derived from.
+        session : orm.Session
+            Active database session.
+
+        Returns
+        -------
+        DataSetHierarchy
+            The created hierarchy record.
+        """
+        return source.add_derived_dataset(self, session)
 
     def align_to_observation(
         self,

--- a/src/lightcurvedb/models/dataset.py
+++ b/src/lightcurvedb/models/dataset.py
@@ -87,6 +87,10 @@ class PhotometricSource(LCDBModel, NameAndDescriptionMixin):
     def __repr__(self) -> str:
         return f"<PhotometricSource(id={self.id!r}, name={self.name!r})>"
 
+    def __rich_repr__(self):
+        yield "id", self.id
+        yield "name", self.name
+
 
 class ProcessingMethod(LCDBModel, NameAndDescriptionMixin):
     """
@@ -158,6 +162,10 @@ class ProcessingMethod(LCDBModel, NameAndDescriptionMixin):
 
     def __repr__(self) -> str:
         return f"<ProcessingMethod(id={self.id!r}, name={self.name!r})>"
+
+    def __rich_repr__(self):
+        yield "id", self.id
+        yield "name", self.name
 
 
 class DataSetHierarchy(LCDBModel):
@@ -291,6 +299,12 @@ class DataSetHierarchy(LCDBModel):
             f"child=(obs={self.child_observation_id}, "
             f"target={self.child_target_id}))>"
         )
+
+    def __rich_repr__(self):
+        yield "source_obs", self.source_observation_id
+        yield "source_target", self.source_target_id
+        yield "child_obs", self.child_observation_id
+        yield "child_target", self.child_target_id
 
 
 class DataSet(LCDBModel):
@@ -659,3 +673,9 @@ class DataSet(LCDBModel):
             f"phot={self.photometric_method_id}, "
             f"proc={self.processing_method_id})>"
         )
+
+    def __rich_repr__(self):
+        yield "obs", self.observation_id
+        yield "target", self.target_id
+        yield "phot", self.photometric_method_id
+        yield "proc", self.processing_method_id

--- a/src/lightcurvedb/models/dataset.py
+++ b/src/lightcurvedb/models/dataset.py
@@ -260,6 +260,7 @@ class DataSetHierarchy(LCDBModel):
             "child_photometric_method_id",
             "child_processing_method_id",
         ),
+        {"postgresql_partition_by": "LIST (source_observation_id)"},
     )
 
     # Source dataset composite key columns

--- a/src/lightcurvedb/models/frame.py
+++ b/src/lightcurvedb/models/frame.py
@@ -86,3 +86,9 @@ class FITSFrame(LCDBModel, CreatedOnMixin):
             f"<{self.__class__.__name__}(id={self.id!r}, type={self.type!r}, "
             f"cadence={self.cadence!r}, obs={self.observation_id!r})>"
         )
+
+    def __rich_repr__(self):
+        yield "id", self.id
+        yield "type", self.type
+        yield "cadence", self.cadence
+        yield "obs", self.observation_id

--- a/src/lightcurvedb/models/frame.py
+++ b/src/lightcurvedb/models/frame.py
@@ -55,14 +55,6 @@ class FITSFrame(LCDBModel, CreatedOnMixin):
         "polymorphic_on": "type",
     }
 
-    __table_args__ = (
-        sa.UniqueConstraint(
-            "type",
-            "cadence",
-            name="distinct_frame_type_cadence_idx",
-        ),
-    )
-
     id: orm.Mapped[int] = orm.mapped_column(primary_key=True)
     type: orm.Mapped[str] = orm.mapped_column(index=True)
     cadence: orm.Mapped[int] = orm.mapped_column(sa.BigInteger, index=True)

--- a/src/lightcurvedb/models/frame.py
+++ b/src/lightcurvedb/models/frame.py
@@ -80,3 +80,9 @@ class FITSFrame(LCDBModel, CreatedOnMixin):
     observation: orm.Mapped["Observation"] = orm.relationship(
         "Observation", back_populates="fits_images"
     )
+
+    def __repr__(self) -> str:
+        return (
+            f"<{self.__class__.__name__}(id={self.id!r}, type={self.type!r}, "
+            f"cadence={self.cadence!r}, obs={self.observation_id!r})>"
+        )

--- a/src/lightcurvedb/models/instrument.py
+++ b/src/lightcurvedb/models/instrument.py
@@ -90,3 +90,9 @@ class Instrument(LCDBModel):
     def __repr__(self) -> str:
         parent_str = f", parent={self.parent_id!s}" if self.parent_id else ""
         return f"<Instrument(id={self.id!s}, name={self.name!r}{parent_str})>"
+
+    def __rich_repr__(self):
+        yield "id", self.id
+        yield "name", self.name
+        if self.parent_id:
+            yield "parent", self.parent_id

--- a/src/lightcurvedb/models/instrument.py
+++ b/src/lightcurvedb/models/instrument.py
@@ -86,3 +86,7 @@ class Instrument(LCDBModel):
         else:
             q = q.where(cls.parent_id.is_(None))
         return q
+
+    def __repr__(self) -> str:
+        parent_str = f", parent={self.parent_id!s}" if self.parent_id else ""
+        return f"<Instrument(id={self.id!s}, name={self.name!r}{parent_str})>"

--- a/src/lightcurvedb/models/observation.py
+++ b/src/lightcurvedb/models/observation.py
@@ -178,6 +178,11 @@ class Observation(LCDBModel):
             f"instrument={self.instrument_id!s})>"
         )
 
+    def __rich_repr__(self):
+        yield "id", self.id
+        yield "type", self.type
+        yield "instrument", self.instrument_id
+
 
 class TargetSpecificTime(LCDBModel):
     """
@@ -244,3 +249,7 @@ class TargetSpecificTime(LCDBModel):
             f"<TargetSpecificTime(obs={self.observation_id!r}, "
             f"target={self.target_id!r})>"
         )
+
+    def __rich_repr__(self):
+        yield "observation_id", self.observation_id
+        yield "target_id", self.target_id

--- a/src/lightcurvedb/models/observation.py
+++ b/src/lightcurvedb/models/observation.py
@@ -156,6 +156,12 @@ class Observation(LCDBModel):
 
         return result
 
+    def __repr__(self) -> str:
+        return (
+            f"<{self.__class__.__name__}(id={self.id!r}, type={self.type!r}, "
+            f"instrument={self.instrument_id!s})>"
+        )
+
 
 class TargetSpecificTime(LCDBModel):
     """
@@ -206,6 +212,12 @@ class TargetSpecificTime(LCDBModel):
     observation: orm.Mapped["Observation"] = orm.relationship(
         back_populates="target_specific_times"
     )
+
+    def __repr__(self) -> str:
+        return (
+            f"<TargetSpecificTime(id={self.id!r}, target={self.target_id!r}, "
+            f"obs={self.observation_id!r})>"
+        )
 
 
 # Create unique constraint on (target_id, observation_id)

--- a/src/lightcurvedb/models/observation.py
+++ b/src/lightcurvedb/models/observation.py
@@ -76,11 +76,11 @@ class Observation(LCDBModel):
         ),
         sa.Index(
             "ix_observation_cadence_min",
-            sa.column("cadence_reference")[1],
+            sa.column("cadence_reference", type_=sa.ARRAY(sa.BIGINT))[1],
         ),
         sa.Index(
             "ix_observation_cadence_max",
-            sa.column("cadence_reference")[
+            sa.column("cadence_reference", type_=sa.ARRAY(sa.BIGINT))[
                 sa.func.cardinality(sa.column("cadence_reference"))
             ],
         ),

--- a/src/lightcurvedb/models/observation.py
+++ b/src/lightcurvedb/models/observation.py
@@ -69,6 +69,22 @@ class Observation(LCDBModel):
         "polymorphic_identity": "observation",
         "polymorphic_on": "type",
     }
+    __table_args__ = (
+        sa.Index(
+            "ix_observation_cadence_length",
+            sa.func.cardinality(sa.column("cadence_reference")),
+        ),
+        sa.Index(
+            "ix_observation_cadence_min",
+            sa.column("cadence_reference")[1],
+        ),
+        sa.Index(
+            "ix_observation_cadence_max",
+            sa.column("cadence_reference")[
+                sa.func.cardinality(sa.column("cadence_reference"))
+            ],
+        ),
+    )
 
     id: orm.Mapped[int] = orm.mapped_column(primary_key=True)
     type: orm.Mapped[str] = orm.mapped_column(index=True)
@@ -171,14 +187,15 @@ class TargetSpecificTime(LCDBModel):
     for the specific position of a target. It serves as a junction
     between Target and Observation with additional time data.
 
+    Uses a composite primary key (observation_id, target_id) and is
+    partitioned by observation_id using PostgreSQL LIST partitioning.
+
     Attributes
     ----------
-    id : int
-        Primary key identifier
-    target_id : int
-        Foreign key to the target
     observation_id : int
-        Foreign key to the observation
+        Foreign key to the observation (part of composite PK, partition key)
+    target_id : int
+        Foreign key to the target (part of composite PK)
     barycentric_julian_dates : ndarray[float64]
         Array of barycentric Julian dates corrected for target position
     target : Target
@@ -195,12 +212,21 @@ class TargetSpecificTime(LCDBModel):
 
     __tablename__ = "target_specific_time"
 
-    id: orm.Mapped[int] = orm.mapped_column(sa.BigInteger, primary_key=True)
-    target_id: orm.Mapped[int] = orm.mapped_column(
-        sa.ForeignKey("target.id", ondelete="CASCADE"), index=True
+    __table_args__ = (
+        sa.PrimaryKeyConstraint(
+            "observation_id", "target_id", name="pk_target_specific_time"
+        ),
+        {"postgresql_partition_by": "LIST (observation_id)"},
     )
+
     observation_id: orm.Mapped[int] = orm.mapped_column(
-        sa.ForeignKey(Observation.id, ondelete="CASCADE"), index=True
+        sa.ForeignKey("observation.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    target_id: orm.Mapped[int] = orm.mapped_column(
+        sa.ForeignKey("target.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
     )
 
     barycentric_julian_dates: orm.Mapped[npt.NDArray[np.float64]]
@@ -215,16 +241,6 @@ class TargetSpecificTime(LCDBModel):
 
     def __repr__(self) -> str:
         return (
-            f"<TargetSpecificTime(id={self.id!r}, target={self.target_id!r}, "
-            f"obs={self.observation_id!r})>"
+            f"<TargetSpecificTime(obs={self.observation_id!r}, "
+            f"target={self.target_id!r})>"
         )
-
-
-# Create unique constraint on (target_id, observation_id)
-# This ensures only one TargetSpecificTime per target-observation pair
-sa.Index(
-    "unique_target_observation_time",
-    TargetSpecificTime.target_id,
-    TargetSpecificTime.observation_id,
-    unique=True,
-)

--- a/src/lightcurvedb/models/quality_flag.py
+++ b/src/lightcurvedb/models/quality_flag.py
@@ -248,6 +248,13 @@ class QualityFlagArray(LCDBModel, CreatedOnMixin):
         "Target", back_populates="quality_flag_arrays"
     )
 
+    def __repr__(self) -> str:
+        target_str = f", target={self.target_id!r}" if self.target_id else ""
+        return (
+            f"<{self.__class__.__name__}(id={self.id!r}, type={self.type!r}, "
+            f"obs={self.observation_id!r}{target_str})>"
+        )
+
 
 # Create unique index that treats NULL target_id values as equal
 # This ensures only one quality flag array per (type, observation_id,

--- a/src/lightcurvedb/models/quality_flag.py
+++ b/src/lightcurvedb/models/quality_flag.py
@@ -255,6 +255,13 @@ class QualityFlagArray(LCDBModel, CreatedOnMixin):
             f"obs={self.observation_id!r}{target_str})>"
         )
 
+    def __rich_repr__(self):
+        yield "id", self.id
+        yield "type", self.type
+        yield "obs", self.observation_id
+        if self.target_id:
+            yield "target", self.target_id
+
 
 # Create unique index that treats NULL target_id values as equal
 # This ensures only one quality flag array per (type, observation_id,

--- a/src/lightcurvedb/models/target.py
+++ b/src/lightcurvedb/models/target.py
@@ -87,6 +87,10 @@ class Mission(LCDBModel, NameAndDescriptionMixin, CreatedOnMixin):
     def __repr__(self) -> str:
         return f"<Mission(id={self.id!s}, name={self.name!r})>"
 
+    def __rich_repr__(self):
+        yield "id", self.id
+        yield "name", self.name
+
 
 class MissionCatalog(LCDBModel, NameAndDescriptionMixin, CreatedOnMixin):
     """
@@ -133,6 +137,11 @@ class MissionCatalog(LCDBModel, NameAndDescriptionMixin, CreatedOnMixin):
             f"<MissionCatalog(id={self.id!r}, name={self.name!r}, "
             f"mission={self.host_mission_id!s})>"
         )
+
+    def __rich_repr__(self):
+        yield "id", self.id
+        yield "name", self.name
+        yield "mission", self.host_mission_id
 
 
 class Target(LCDBModel):
@@ -200,3 +209,8 @@ class Target(LCDBModel):
             f"<Target(id={self.id!r}, catalog={self.catalog_id!r}, "
             f"name={self.name!r})>"
         )
+
+    def __rich_repr__(self):
+        yield "id", self.id
+        yield "catalog", self.catalog_id
+        yield "name", self.name

--- a/src/lightcurvedb/models/target.py
+++ b/src/lightcurvedb/models/target.py
@@ -84,6 +84,9 @@ class Mission(LCDBModel, NameAndDescriptionMixin, CreatedOnMixin):
         back_populates="host_mission"
     )
 
+    def __repr__(self) -> str:
+        return f"<Mission(id={self.id!s}, name={self.name!r})>"
+
 
 class MissionCatalog(LCDBModel, NameAndDescriptionMixin, CreatedOnMixin):
     """
@@ -124,6 +127,12 @@ class MissionCatalog(LCDBModel, NameAndDescriptionMixin, CreatedOnMixin):
     targets: orm.Mapped[list["Target"]] = orm.relationship(
         back_populates="catalog"
     )
+
+    def __repr__(self) -> str:
+        return (
+            f"<MissionCatalog(id={self.id!r}, name={self.name!r}, "
+            f"mission={self.host_mission_id!s})>"
+        )
 
 
 class Target(LCDBModel):
@@ -185,3 +194,9 @@ class Target(LCDBModel):
     quality_flag_arrays: orm.Mapped[
         list["QualityFlagArray"]
     ] = orm.relationship(back_populates="target")
+
+    def __repr__(self) -> str:
+        return (
+            f"<Target(id={self.id!r}, catalog={self.catalog_id!r}, "
+            f"name={self.name!r})>"
+        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -141,6 +141,18 @@ def v2_db(worker_database):
                 "PARTITION OF dataset DEFAULT"
             )
         )
+        conn.execute(
+            sa.text(
+                "CREATE TABLE IF NOT EXISTS target_specific_time_default "
+                "PARTITION OF target_specific_time DEFAULT"
+            )
+        )
+        conn.execute(
+            sa.text(
+                "CREATE TABLE IF NOT EXISTS datasethierarchy_default "
+                "PARTITION OF datasethierarchy DEFAULT"
+            )
+        )
         conn.commit()
 
     Session = sessionmaker()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -131,6 +131,18 @@ def v2_db(worker_database):
 
     # Create tables for this test
     LCDBModel.metadata.create_all(bind=engine, checkfirst=True)
+
+    # Create default partition for the partitioned dataset table
+    # This is required because the dataset table uses LIST partitioning
+    with engine.connect() as conn:
+        conn.execute(
+            sa.text(
+                "CREATE TABLE IF NOT EXISTS dataset_default "
+                "PARTITION OF dataset DEFAULT"
+            )
+        )
+        conn.commit()
+
     Session = sessionmaker()
     Session.configure(bind=engine)
 
@@ -141,6 +153,14 @@ def v2_db(worker_database):
 
     try:
         session = Session()
+
+        # Create sentinel records for composite key support
+        from lightcurvedb.models import PhotometricSource, ProcessingMethod
+
+        PhotometricSource.get_or_create_unspecified(session)
+        ProcessingMethod.get_or_create_unspecified(session)
+        session.commit()
+
         yield session
         session.close()
     finally:

--- a/tests/test_dataset_relationships.py
+++ b/tests/test_dataset_relationships.py
@@ -73,9 +73,10 @@ class TestQLPLightcurveHierarchies:
         v2_db.add(ccd_1)
         v2_db.flush()
 
-        # Add all apertures
+        # Add all apertures (explicit IDs since autoincrement=False)
         legacy_apertures = [
             PhotometricSource(
+                id=i + 1,  # Start from 1, 0 is reserved for sentinel
                 name=f"Aperture_{i:03d}",  # noqa: E231
                 description="Older FiPhot based SAP",
             )
@@ -83,27 +84,31 @@ class TestQLPLightcurveHierarchies:
         ]
         legacy_apertures.append(
             PhotometricSource(
+                id=6,
                 name="Background Aperture",
                 description="A ringed aperture for extracting background flux",
             )
         )
         v2_db.add_all(legacy_apertures)
-        # Add TGLC apertures
+        # Add TGLC apertures (explicit IDs since autoincrement=False)
         tglc_apertures: list[PhotometricSource] = []
         tglc_apertures.append(
             PhotometricSource(
+                id=7,
                 name="TGLC Small Aperture",
                 description="A 1x1 Single Pixel Aperture from TGLC",
             )
         )
         tglc_apertures.append(
             PhotometricSource(
+                id=8,
                 name="TGLC Primary Aperture",
                 description="A 3x3 Pixel Aperture from TGLC",
             )
         )
         tglc_apertures.append(
             PhotometricSource(
+                id=9,
                 name="TGLC Large Aperture",
                 description="A 5x5 Aperture from TGLC",
             )
@@ -111,30 +116,38 @@ class TestQLPLightcurveHierarchies:
 
         v2_db.add_all(tglc_apertures)
 
-        # Add Detrending Types
+        # Add Detrending Types (explicit IDs since autoincrement=False)
         processing_methods = [
             ProcessingMethod(
+                id=1,
                 name="QSPIntermediateMagnitude",
                 description="Systematic Corrected Lightcurves",
             ),
             ProcessingMethod(
+                id=2,
                 name="QSPMagnitude",
                 description="Stellar and Quaternion based detrending",
             ),
             ProcessingMethod(
-                name="KSPMagnitude", description="Kepler Spline detrending"
+                id=3,
+                name="KSPMagnitude",
+                description="Kepler Spline detrending",
             ),
         ]
         v2_db.add_all(processing_methods)
         v2_db.flush()
 
-        # Add spatial types
+        # Add spatial types (explicit IDs since autoincrement=False)
         spatial_methods = [
             ProcessingMethod(
-                name="FFI X Position", description="X Centroid Information"
+                id=4,
+                name="FFI X Position",
+                description="X Centroid Information",
             ),
             ProcessingMethod(
-                name="FFI Y Position", description="Y Centroid Information"
+                id=5,
+                name="FFI Y Position",
+                description="Y Centroid Information",
             ),
         ]
         v2_db.add_all(spatial_methods)
@@ -172,7 +185,7 @@ class TestQLPLightcurveHierarchies:
                 target=t,
                 observation=observation,
                 photometry_source=source,
-                processing_method=None,  # No processing has been done...
+                processing_method_id=ProcessingMethod.UNSPECIFIED_ID,
             )
             # Add XY positions
             x_coordinates = DataSet(
@@ -223,8 +236,11 @@ class TestQLPLightcurveHierarchies:
                 processing_method=processing_methods[1],
             )
             v2_db.add_all([ksp, sys_removed, detrended])
-            raw_photometry.derived_datasets.append(ksp)
-            raw_photometry.derived_datasets.append(sys_removed)
-            sys_removed.derived_datasets.append(detrended)
+            v2_db.flush()
+
+            # Create hierarchy using helper methods (viewonly relationships)
+            raw_photometry.add_derived_dataset(ksp, v2_db)
+            raw_photometry.add_derived_dataset(sys_removed, v2_db)
+            sys_removed.add_derived_dataset(detrended, v2_db)
 
             v2_db.commit()

--- a/tests/test_dataset_relationships.py
+++ b/tests/test_dataset_relationships.py
@@ -886,16 +886,23 @@ class TestHybridPropertyFiltering:
         sample_observation: Observation,
     ):
         """Test combining hybrid property filters."""
-        # Create sources and methods
+        # Create all sources and methods first, then flush once
         source = PhotometricSource(
             id=320, name="CombSrc", description="Comb Source"
+        )
+        source2 = PhotometricSource(
+            id=321, name="CombSrc2", description="Src2"
         )
         method = ProcessingMethod(
             id=320, name="CombMeth", description="Comb Method"
         )
-        v2_db.add_all([source, method])
+        method2 = ProcessingMethod(
+            id=321, name="CombMeth2", description="Meth2"
+        )
+        v2_db.add_all([source, source2, method, method2])
         v2_db.flush()
 
+        # Now create all datasets (after sources/methods are in session)
         # Dataset with both (has source AND has method)
         both = DataSet(
             values=np.random.normal(0, 1, 100),
@@ -906,12 +913,6 @@ class TestHybridPropertyFiltering:
         )
 
         # Dataset with source only (has source, no method)
-        source2 = PhotometricSource(
-            id=321, name="CombSrc2", description="Src2"
-        )
-        v2_db.add(source2)
-        v2_db.flush()
-
         source_only = DataSet(
             values=np.random.normal(0, 1, 100),
             target=sample_target,
@@ -921,12 +922,6 @@ class TestHybridPropertyFiltering:
         )
 
         # Dataset with method only (no source, has method)
-        method2 = ProcessingMethod(
-            id=321, name="CombMeth2", description="Meth2"
-        )
-        v2_db.add(method2)
-        v2_db.flush()
-
         method_only = DataSet(
             values=np.random.normal(0, 1, 100),
             target=sample_target,
@@ -1317,6 +1312,10 @@ class TestCompositeKeyQueries:
 
         assert len(results) == 3
 
+    @pytest.mark.filterwarnings(
+        "ignore:New instance .* conflicts with persistent "
+        "instance:sqlalchemy.exc.SAWarning"
+    )
     def test_unique_constraint_composite_key(
         self,
         v2_db: orm.Session,

--- a/tests/test_dataset_relationships.py
+++ b/tests/test_dataset_relationships.py
@@ -1,6 +1,8 @@
 import numpy as np
+import pytest
 import sqlalchemy as sa
 from sqlalchemy import orm
+from sqlalchemy.exc import IntegrityError
 
 from lightcurvedb.core.base_model import LCDBModel
 from lightcurvedb.models import (
@@ -9,9 +11,103 @@ from lightcurvedb.models import (
     PhotometricSource,
     ProcessingMethod,
 )
-from lightcurvedb.models.dataset import DataSet
+from lightcurvedb.models.dataset import DataSet, DataSetHierarchy
 from lightcurvedb.models.observation import TargetSpecificTime
 from lightcurvedb.models.target import Mission, MissionCatalog, Target
+
+# -----------------------------------------------------------------------------
+# Test Fixtures
+# -----------------------------------------------------------------------------
+
+
+@pytest.fixture
+def sample_mission(v2_db: orm.Session) -> Mission:
+    """Create a sample mission for tests."""
+    mission = Mission(
+        name="Test Mission",
+        description="A test mission",
+        time_unit="day",
+        time_epoch=2457000,
+        time_epoch_scale="tdb",
+        time_epoch_format="jd",
+        time_format_name="test_time",
+    )
+    v2_db.add(mission)
+    v2_db.flush()
+    return mission
+
+
+@pytest.fixture
+def sample_catalog(
+    v2_db: orm.Session, sample_mission: Mission
+) -> MissionCatalog:
+    """Create a sample catalog for tests."""
+    catalog = MissionCatalog(
+        name="Test Catalog",
+        description="A test catalog",
+        host_mission=sample_mission,
+    )
+    v2_db.add(catalog)
+    v2_db.flush()
+    return catalog
+
+
+@pytest.fixture
+def sample_target(
+    v2_db: orm.Session, sample_catalog: MissionCatalog
+) -> Target:
+    """Create a sample target for tests."""
+    target = Target(catalog=sample_catalog, name=123456789)
+    v2_db.add(target)
+    v2_db.flush()
+    return target
+
+
+@pytest.fixture
+def sample_instrument(v2_db: orm.Session) -> Instrument:
+    """Create a sample instrument for tests."""
+    instrument = Instrument(
+        name="Test Instrument", properties={"type": "test"}
+    )
+    v2_db.add(instrument)
+    v2_db.flush()
+    return instrument
+
+
+@pytest.fixture
+def sample_observation(
+    v2_db: orm.Session, sample_instrument: Instrument
+) -> Observation:
+    """Create a sample observation for tests."""
+    observation = Observation(
+        instrument=sample_instrument,
+        cadence_reference=np.arange(100),
+    )
+    v2_db.add(observation)
+    v2_db.flush()
+    return observation
+
+
+@pytest.fixture
+def sample_photometric_source(v2_db: orm.Session) -> PhotometricSource:
+    """Create a named photometric source (not sentinel)."""
+    source = PhotometricSource(
+        id=100, name="Test Aperture", description="Test aperture"
+    )
+    v2_db.add(source)
+    v2_db.flush()
+    return source
+
+
+@pytest.fixture
+def sample_processing_method(v2_db: orm.Session) -> ProcessingMethod:
+    """Create a named processing method (not sentinel)."""
+    method = ProcessingMethod(
+        id=100, name="Test Method", description="Test processing method"
+    )
+    v2_db.add(method)
+    v2_db.flush()
+    return method
 
 
 class Orbit(LCDBModel):
@@ -244,3 +340,1021 @@ class TestQLPLightcurveHierarchies:
             sys_removed.add_derived_dataset(detrended, v2_db)
 
             v2_db.commit()
+
+
+# -----------------------------------------------------------------------------
+# Hierarchy Traversal Tests
+# -----------------------------------------------------------------------------
+
+
+class TestDataSetHierarchy:
+    """Tests for DataSet hierarchy relationships."""
+
+    def test_derived_datasets_retrieval(
+        self,
+        v2_db: orm.Session,
+        sample_target: Target,
+        sample_observation: Observation,
+        sample_photometric_source: PhotometricSource,
+    ):
+        """Test accessing derived datasets through derived_datasets."""
+        # Create source dataset (raw)
+        source = DataSet(
+            values=np.random.normal(0, 1, 100),
+            errors=np.random.normal(0, 0.1, 100),
+            target=sample_target,
+            observation=sample_observation,
+            photometry_source=sample_photometric_source,
+            processing_method_id=ProcessingMethod.UNSPECIFIED_ID,
+        )
+        v2_db.add(source)
+        v2_db.flush()
+
+        # Create derived dataset (processed)
+        processing = ProcessingMethod(
+            id=101, name="Detrend", description="Detrend"
+        )
+        v2_db.add(processing)
+        v2_db.flush()
+
+        derived = DataSet(
+            values=np.random.normal(0, 1, 100),
+            errors=np.random.normal(0, 0.1, 100),
+            target=sample_target,
+            observation=sample_observation,
+            photometry_source=sample_photometric_source,
+            processing_method=processing,
+        )
+        v2_db.add(derived)
+        v2_db.flush()
+
+        # Create hierarchy link
+        source.add_derived_dataset(derived, v2_db)
+        v2_db.commit()
+
+        # Refresh to load relationships
+        v2_db.refresh(source)
+        v2_db.refresh(derived)
+
+        # Test derived_datasets retrieval
+        assert len(source.derived_datasets) == 1
+        assert derived in source.derived_datasets
+
+        # Test source_datasets retrieval (inverse)
+        assert len(derived.source_datasets) == 1
+        assert source in derived.source_datasets
+
+    def test_multilevel_hierarchy(
+        self,
+        v2_db: orm.Session,
+        sample_target: Target,
+        sample_observation: Observation,
+        sample_photometric_source: PhotometricSource,
+    ):
+        """Test A -> B -> C hierarchy traversal."""
+        # Create processing methods
+        methods = [
+            ProcessingMethod(
+                id=110 + i, name=f"Level{i}", description=f"Level {i}"
+            )
+            for i in range(3)
+        ]
+        v2_db.add_all(methods)
+        v2_db.flush()
+
+        # Create 3 datasets in chain: raw -> intermediate -> final
+        datasets = []
+        for i, method in enumerate(methods):
+            ds = DataSet(
+                values=np.random.normal(0, 1, 100),
+                target=sample_target,
+                observation=sample_observation,
+                photometry_source=sample_photometric_source,
+                processing_method=method,
+            )
+            datasets.append(ds)
+            v2_db.add(ds)
+        v2_db.flush()
+
+        # Create chain hierarchy: A -> B -> C
+        datasets[0].add_derived_dataset(datasets[1], v2_db)
+        datasets[1].add_derived_dataset(datasets[2], v2_db)
+        v2_db.commit()
+
+        # Refresh
+        for ds in datasets:
+            v2_db.refresh(ds)
+
+        # Verify relationships
+        assert len(datasets[0].derived_datasets) == 1
+        assert datasets[1] in datasets[0].derived_datasets
+        assert len(datasets[0].source_datasets) == 0
+
+        assert len(datasets[1].derived_datasets) == 1
+        assert datasets[2] in datasets[1].derived_datasets
+        assert len(datasets[1].source_datasets) == 1
+        assert datasets[0] in datasets[1].source_datasets
+
+        assert len(datasets[2].derived_datasets) == 0
+        assert len(datasets[2].source_datasets) == 1
+        assert datasets[1] in datasets[2].source_datasets
+
+    def test_branching_hierarchy(
+        self,
+        v2_db: orm.Session,
+        sample_target: Target,
+        sample_observation: Observation,
+        sample_photometric_source: PhotometricSource,
+    ):
+        """Test single source with multiple derived datasets."""
+        # Create processing methods
+        methods = [
+            ProcessingMethod(
+                id=120 + i, name=f"Branch{i}", description=f"Branch {i}"
+            )
+            for i in range(4)
+        ]
+        v2_db.add_all(methods)
+        v2_db.flush()
+
+        # Create source dataset
+        source = DataSet(
+            values=np.random.normal(0, 1, 100),
+            target=sample_target,
+            observation=sample_observation,
+            photometry_source=sample_photometric_source,
+            processing_method=methods[0],
+        )
+        v2_db.add(source)
+        v2_db.flush()
+
+        # Create 3 derived datasets from same source
+        derived_datasets = []
+        for method in methods[1:]:
+            ds = DataSet(
+                values=np.random.normal(0, 1, 100),
+                target=sample_target,
+                observation=sample_observation,
+                photometry_source=sample_photometric_source,
+                processing_method=method,
+            )
+            derived_datasets.append(ds)
+            v2_db.add(ds)
+        v2_db.flush()
+
+        # Create hierarchy links
+        for derived in derived_datasets:
+            source.add_derived_dataset(derived, v2_db)
+        v2_db.commit()
+
+        # Refresh
+        v2_db.refresh(source)
+
+        # Verify branching
+        assert len(source.derived_datasets) == 3
+        for derived in derived_datasets:
+            assert derived in source.derived_datasets
+
+    def test_diamond_dependency(
+        self,
+        v2_db: orm.Session,
+        sample_target: Target,
+        sample_observation: Observation,
+    ):
+        """Test multiple sources converging to single derived."""
+        # Create photometric sources
+        sources = [
+            PhotometricSource(
+                id=130 + i, name=f"Source{i}", description=f"Source {i}"
+            )
+            for i in range(3)
+        ]
+        v2_db.add_all(sources)
+        v2_db.flush()
+
+        # Create processing method
+        method = ProcessingMethod(
+            id=130, name="Combine", description="Combined"
+        )
+        v2_db.add(method)
+        v2_db.flush()
+
+        # Create 2 source datasets
+        source1 = DataSet(
+            values=np.random.normal(0, 1, 100),
+            target=sample_target,
+            observation=sample_observation,
+            photometry_source=sources[0],
+            processing_method_id=ProcessingMethod.UNSPECIFIED_ID,
+        )
+        source2 = DataSet(
+            values=np.random.normal(0, 1, 100),
+            target=sample_target,
+            observation=sample_observation,
+            photometry_source=sources[1],
+            processing_method_id=ProcessingMethod.UNSPECIFIED_ID,
+        )
+        v2_db.add_all([source1, source2])
+        v2_db.flush()
+
+        # Create derived dataset that combines both sources
+        combined = DataSet(
+            values=np.random.normal(0, 1, 100),
+            target=sample_target,
+            observation=sample_observation,
+            photometry_source=sources[2],
+            processing_method=method,
+        )
+        v2_db.add(combined)
+        v2_db.flush()
+
+        # Link both sources to combined
+        source1.add_derived_dataset(combined, v2_db)
+        source2.add_derived_dataset(combined, v2_db)
+        v2_db.commit()
+
+        # Refresh
+        v2_db.refresh(combined)
+
+        # Verify diamond
+        assert len(combined.source_datasets) == 2
+        assert source1 in combined.source_datasets
+        assert source2 in combined.source_datasets
+
+
+# -----------------------------------------------------------------------------
+# Relationship Retrieval Tests
+# -----------------------------------------------------------------------------
+
+
+class TestDataSetRetrieval:
+    """Tests for DataSet retrieval through related models."""
+
+    def test_target_datasets_retrieval(
+        self,
+        v2_db: orm.Session,
+        sample_target: Target,
+        sample_observation: Observation,
+    ):
+        """Test accessing datasets via target.datasets relationship."""
+        # Create multiple photometric sources
+        sources = [
+            PhotometricSource(
+                id=200 + i, name=f"Src{i}", description=f"Source {i}"
+            )
+            for i in range(3)
+        ]
+        v2_db.add_all(sources)
+        v2_db.flush()
+
+        # Create datasets for the target
+        datasets = []
+        for source in sources:
+            ds = DataSet(
+                values=np.random.normal(0, 1, 100),
+                target=sample_target,
+                observation=sample_observation,
+                photometry_source=source,
+                processing_method_id=ProcessingMethod.UNSPECIFIED_ID,
+            )
+            datasets.append(ds)
+            v2_db.add(ds)
+        v2_db.flush()
+        v2_db.commit()
+
+        # Refresh target
+        v2_db.refresh(sample_target)
+
+        # Verify retrieval through target
+        assert len(sample_target.datasets) == 3
+        for ds in datasets:
+            assert ds in sample_target.datasets
+
+    def test_observation_datasets_retrieval(
+        self,
+        v2_db: orm.Session,
+        sample_target: Target,
+        sample_observation: Observation,
+    ):
+        """Test accessing datasets via observation.datasets relationship."""
+        # Create multiple photometric sources
+        sources = [
+            PhotometricSource(
+                id=210 + i, name=f"ObsSrc{i}", description=f"Src {i}"
+            )
+            for i in range(3)
+        ]
+        v2_db.add_all(sources)
+        v2_db.flush()
+
+        # Create datasets for the observation
+        datasets = []
+        for source in sources:
+            ds = DataSet(
+                values=np.random.normal(0, 1, 100),
+                target=sample_target,
+                observation=sample_observation,
+                photometry_source=source,
+                processing_method_id=ProcessingMethod.UNSPECIFIED_ID,
+            )
+            datasets.append(ds)
+            v2_db.add(ds)
+        v2_db.flush()
+        v2_db.commit()
+
+        # Refresh observation
+        v2_db.refresh(sample_observation)
+
+        # Verify retrieval through observation
+        assert len(sample_observation.datasets) == 3
+        for ds in datasets:
+            assert ds in sample_observation.datasets
+
+    def test_photometric_source_datasets_retrieval(
+        self,
+        v2_db: orm.Session,
+        sample_target: Target,
+        sample_observation: Observation,
+        sample_photometric_source: PhotometricSource,
+    ):
+        """Test accessing datasets via photometric_source.datasets."""
+        # Create multiple processing methods
+        methods = [
+            ProcessingMethod(
+                id=220 + i, name=f"PsMethod{i}", description=f"M {i}"
+            )
+            for i in range(3)
+        ]
+        v2_db.add_all(methods)
+        v2_db.flush()
+
+        # Create datasets with same photometric source
+        datasets = []
+        for method in methods:
+            ds = DataSet(
+                values=np.random.normal(0, 1, 100),
+                target=sample_target,
+                observation=sample_observation,
+                photometry_source=sample_photometric_source,
+                processing_method=method,
+            )
+            datasets.append(ds)
+            v2_db.add(ds)
+        v2_db.flush()
+        v2_db.commit()
+
+        # Refresh photometric source
+        v2_db.refresh(sample_photometric_source)
+
+        # Verify retrieval through photometric source
+        assert len(sample_photometric_source.datasets) == 3
+        for ds in datasets:
+            assert ds in sample_photometric_source.datasets
+
+    def test_processing_method_datasets_retrieval(
+        self,
+        v2_db: orm.Session,
+        sample_target: Target,
+        sample_observation: Observation,
+        sample_processing_method: ProcessingMethod,
+    ):
+        """Test accessing datasets via processing_method.datasets."""
+        # Create multiple photometric sources
+        sources = [
+            PhotometricSource(
+                id=230 + i, name=f"PmSrc{i}", description=f"S {i}"
+            )
+            for i in range(3)
+        ]
+        v2_db.add_all(sources)
+        v2_db.flush()
+
+        # Create datasets with same processing method
+        datasets = []
+        for source in sources:
+            ds = DataSet(
+                values=np.random.normal(0, 1, 100),
+                target=sample_target,
+                observation=sample_observation,
+                photometry_source=source,
+                processing_method=sample_processing_method,
+            )
+            datasets.append(ds)
+            v2_db.add(ds)
+        v2_db.flush()
+        v2_db.commit()
+
+        # Refresh processing method
+        v2_db.refresh(sample_processing_method)
+
+        # Verify retrieval through processing method
+        assert len(sample_processing_method.datasets) == 3
+        for ds in datasets:
+            assert ds in sample_processing_method.datasets
+
+
+# -----------------------------------------------------------------------------
+# Hybrid Property Filtering Tests
+# -----------------------------------------------------------------------------
+
+
+class TestHybridPropertyFiltering:
+    """Tests for DataSet hybrid property SQL filtering."""
+
+    def test_filter_has_photometric_source(
+        self,
+        v2_db: orm.Session,
+        sample_target: Target,
+        sample_observation: Observation,
+        sample_photometric_source: PhotometricSource,
+    ):
+        """Test filtering datasets with photometric source via SQL."""
+        # Create dataset with photometric source (not sentinel)
+        with_source = DataSet(
+            values=np.random.normal(0, 1, 100),
+            target=sample_target,
+            observation=sample_observation,
+            photometry_source=sample_photometric_source,
+            processing_method_id=ProcessingMethod.UNSPECIFIED_ID,
+        )
+        v2_db.add(with_source)
+        v2_db.flush()
+
+        # Create dataset with sentinel (no photometric source)
+        method = ProcessingMethod(id=300, name="HpTest", description="HP test")
+        v2_db.add(method)
+        v2_db.flush()
+
+        without_source = DataSet(
+            values=np.random.normal(0, 1, 100),
+            target=sample_target,
+            observation=sample_observation,
+            photometric_method_id=PhotometricSource.UNSPECIFIED_ID,
+            processing_method=method,
+        )
+        v2_db.add(without_source)
+        v2_db.commit()
+
+        # Query using hybrid property
+        with_source_results = (
+            v2_db.query(DataSet)
+            .filter(DataSet.has_photometric_source == True)  # noqa: E712
+            .filter(DataSet.target_id == sample_target.id)
+            .all()
+        )
+        without_source_results = (
+            v2_db.query(DataSet)
+            .filter(DataSet.has_photometric_source == False)  # noqa: E712
+            .filter(DataSet.target_id == sample_target.id)
+            .all()
+        )
+
+        assert len(with_source_results) == 1
+        assert with_source in with_source_results
+
+        assert len(without_source_results) == 1
+        assert without_source in without_source_results
+
+    def test_filter_has_processing_method(
+        self,
+        v2_db: orm.Session,
+        sample_target: Target,
+        sample_observation: Observation,
+        sample_processing_method: ProcessingMethod,
+    ):
+        """Test filtering datasets with processing method via SQL."""
+        # Create photometric source
+        source = PhotometricSource(
+            id=310, name="HpSource", description="HP Source"
+        )
+        v2_db.add(source)
+        v2_db.flush()
+
+        # Create dataset with processing method (not sentinel)
+        with_method = DataSet(
+            values=np.random.normal(0, 1, 100),
+            target=sample_target,
+            observation=sample_observation,
+            photometry_source=source,
+            processing_method=sample_processing_method,
+        )
+        v2_db.add(with_method)
+        v2_db.flush()
+
+        # Create another source for the sentinel dataset
+        source2 = PhotometricSource(
+            id=311, name="HpSource2", description="HP Source2"
+        )
+        v2_db.add(source2)
+        v2_db.flush()
+
+        # Create dataset with sentinel (no processing method - raw)
+        without_method = DataSet(
+            values=np.random.normal(0, 1, 100),
+            target=sample_target,
+            observation=sample_observation,
+            photometry_source=source2,
+            processing_method_id=ProcessingMethod.UNSPECIFIED_ID,
+        )
+        v2_db.add(without_method)
+        v2_db.commit()
+
+        # Query using hybrid property
+        with_method_results = (
+            v2_db.query(DataSet)
+            .filter(DataSet.has_processing_method == True)  # noqa: E712
+            .filter(DataSet.target_id == sample_target.id)
+            .all()
+        )
+        without_method_results = (
+            v2_db.query(DataSet)
+            .filter(DataSet.has_processing_method == False)  # noqa: E712
+            .filter(DataSet.target_id == sample_target.id)
+            .all()
+        )
+
+        assert len(with_method_results) == 1
+        assert with_method in with_method_results
+
+        assert len(without_method_results) == 1
+        assert without_method in without_method_results
+
+    def test_filter_combined_hybrid_properties(
+        self,
+        v2_db: orm.Session,
+        sample_target: Target,
+        sample_observation: Observation,
+    ):
+        """Test combining hybrid property filters."""
+        # Create sources and methods
+        source = PhotometricSource(
+            id=320, name="CombSrc", description="Comb Source"
+        )
+        method = ProcessingMethod(
+            id=320, name="CombMeth", description="Comb Method"
+        )
+        v2_db.add_all([source, method])
+        v2_db.flush()
+
+        # Dataset with both (has source AND has method)
+        both = DataSet(
+            values=np.random.normal(0, 1, 100),
+            target=sample_target,
+            observation=sample_observation,
+            photometry_source=source,
+            processing_method=method,
+        )
+
+        # Dataset with source only (has source, no method)
+        source2 = PhotometricSource(
+            id=321, name="CombSrc2", description="Src2"
+        )
+        v2_db.add(source2)
+        v2_db.flush()
+
+        source_only = DataSet(
+            values=np.random.normal(0, 1, 100),
+            target=sample_target,
+            observation=sample_observation,
+            photometry_source=source2,
+            processing_method_id=ProcessingMethod.UNSPECIFIED_ID,
+        )
+
+        # Dataset with method only (no source, has method)
+        method2 = ProcessingMethod(
+            id=321, name="CombMeth2", description="Meth2"
+        )
+        v2_db.add(method2)
+        v2_db.flush()
+
+        method_only = DataSet(
+            values=np.random.normal(0, 1, 100),
+            target=sample_target,
+            observation=sample_observation,
+            photometric_method_id=PhotometricSource.UNSPECIFIED_ID,
+            processing_method=method2,
+        )
+
+        # Dataset with neither (no source, no method)
+        neither = DataSet(
+            values=np.random.normal(0, 1, 100),
+            target=sample_target,
+            observation=sample_observation,
+            photometric_method_id=PhotometricSource.UNSPECIFIED_ID,
+            processing_method_id=ProcessingMethod.UNSPECIFIED_ID,
+        )
+
+        v2_db.add_all([both, source_only, method_only, neither])
+        v2_db.commit()
+
+        # Query: has both
+        both_results = (
+            v2_db.query(DataSet)
+            .filter(DataSet.has_photometric_source == True)  # noqa: E712
+            .filter(DataSet.has_processing_method == True)  # noqa: E712
+            .filter(DataSet.target_id == sample_target.id)
+            .all()
+        )
+        assert len(both_results) == 1
+        assert both in both_results
+
+        # Query: has source but not method
+        source_no_method = (
+            v2_db.query(DataSet)
+            .filter(DataSet.has_photometric_source == True)  # noqa: E712
+            .filter(DataSet.has_processing_method == False)  # noqa: E712
+            .filter(DataSet.target_id == sample_target.id)
+            .all()
+        )
+        assert len(source_no_method) == 1
+        assert source_only in source_no_method
+
+        # Query: has neither
+        has_neither = (
+            v2_db.query(DataSet)
+            .filter(DataSet.has_photometric_source == False)  # noqa: E712
+            .filter(DataSet.has_processing_method == False)  # noqa: E712
+            .filter(DataSet.target_id == sample_target.id)
+            .all()
+        )
+        assert len(has_neither) == 1
+        assert neither in has_neither
+
+
+# -----------------------------------------------------------------------------
+# Cascade Delete Tests
+# -----------------------------------------------------------------------------
+
+
+class TestCascadeDelete:
+    """Tests for DataSet cascade delete behavior."""
+
+    def test_observation_delete_cascades_to_datasets(
+        self,
+        v2_db: orm.Session,
+        sample_target: Target,
+        sample_instrument: Instrument,
+    ):
+        """Test deleting observation cascades to its datasets."""
+        # Create observation
+        observation = Observation(
+            instrument=sample_instrument,
+            cadence_reference=np.arange(50),
+        )
+        v2_db.add(observation)
+        v2_db.flush()
+
+        obs_id = observation.id
+
+        # Create photometric source
+        source = PhotometricSource(
+            id=400, name="CascSrc", description="Cascade Source"
+        )
+        v2_db.add(source)
+        v2_db.flush()
+
+        # Create dataset
+        ds = DataSet(
+            values=np.random.normal(0, 1, 50),
+            target=sample_target,
+            observation=observation,
+            photometry_source=source,
+            processing_method_id=ProcessingMethod.UNSPECIFIED_ID,
+        )
+        v2_db.add(ds)
+        v2_db.commit()
+
+        # Verify dataset exists
+        count_before = (
+            v2_db.query(DataSet)
+            .filter(DataSet.observation_id == obs_id)
+            .count()
+        )
+        assert count_before == 1
+
+        # Delete via SQL to trigger database-level CASCADE
+        # (ORM delete doesn't trigger ondelete CASCADE)
+        v2_db.execute(sa.delete(Observation).where(Observation.id == obs_id))
+        v2_db.commit()
+
+        # Verify dataset was cascaded
+        count_after = (
+            v2_db.query(DataSet)
+            .filter(DataSet.observation_id == obs_id)
+            .count()
+        )
+        assert count_after == 0
+
+    def test_target_delete_cascades_to_datasets(
+        self,
+        v2_db: orm.Session,
+        sample_catalog: MissionCatalog,
+        sample_observation: Observation,
+    ):
+        """Test deleting target cascades to its datasets."""
+        # Create target
+        target = Target(catalog=sample_catalog, name=999888777)
+        v2_db.add(target)
+        v2_db.flush()
+
+        target_id = target.id
+
+        # Create photometric source
+        source = PhotometricSource(
+            id=410, name="TgtCascSrc", description="Target Cascade"
+        )
+        v2_db.add(source)
+        v2_db.flush()
+
+        # Create dataset
+        ds = DataSet(
+            values=np.random.normal(0, 1, 100),
+            target=target,
+            observation=sample_observation,
+            photometry_source=source,
+            processing_method_id=ProcessingMethod.UNSPECIFIED_ID,
+        )
+        v2_db.add(ds)
+        v2_db.commit()
+
+        # Verify dataset exists
+        count_before = (
+            v2_db.query(DataSet).filter(DataSet.target_id == target_id).count()
+        )
+        assert count_before == 1
+
+        # Delete target via SQL to trigger database-level CASCADE
+        v2_db.execute(sa.delete(Target).where(Target.id == target_id))
+        v2_db.commit()
+
+        # Verify dataset was cascaded
+        count_after = (
+            v2_db.query(DataSet).filter(DataSet.target_id == target_id).count()
+        )
+        assert count_after == 0
+
+    def test_dataset_delete_cascades_to_hierarchy(
+        self,
+        v2_db: orm.Session,
+        sample_target: Target,
+        sample_observation: Observation,
+    ):
+        """Test deleting dataset cascades to hierarchy entries."""
+        # Create sources and methods
+        sources = [
+            PhotometricSource(
+                id=420 + i, name=f"HierSrc{i}", description=f"H {i}"
+            )
+            for i in range(2)
+        ]
+        v2_db.add_all(sources)
+        v2_db.flush()
+
+        # Create source dataset
+        source_ds = DataSet(
+            values=np.random.normal(0, 1, 100),
+            target=sample_target,
+            observation=sample_observation,
+            photometry_source=sources[0],
+            processing_method_id=ProcessingMethod.UNSPECIFIED_ID,
+        )
+        v2_db.add(source_ds)
+        v2_db.flush()
+
+        # Create derived dataset
+        derived_ds = DataSet(
+            values=np.random.normal(0, 1, 100),
+            target=sample_target,
+            observation=sample_observation,
+            photometry_source=sources[1],
+            processing_method_id=ProcessingMethod.UNSPECIFIED_ID,
+        )
+        v2_db.add(derived_ds)
+        v2_db.flush()
+
+        # Create hierarchy link
+        source_ds.add_derived_dataset(derived_ds, v2_db)
+        v2_db.commit()
+
+        # Verify hierarchy exists
+        hierarchy_count_before = v2_db.query(DataSetHierarchy).count()
+        assert hierarchy_count_before >= 1
+
+        # Delete source dataset
+        v2_db.delete(source_ds)
+        v2_db.commit()
+
+        # Verify hierarchy entry was cascaded (check for this specific link)
+        remaining = (
+            v2_db.query(DataSetHierarchy)
+            .filter(
+                DataSetHierarchy.source_photometric_method_id == sources[0].id,
+                DataSetHierarchy.child_photometric_method_id == sources[1].id,
+            )
+            .count()
+        )
+        assert remaining == 0
+
+    def test_photometric_source_delete_restricted(
+        self,
+        v2_db: orm.Session,
+        sample_target: Target,
+        sample_observation: Observation,
+    ):
+        """Test deleting photometric source fails when datasets exist."""
+        # Create photometric source
+        source = PhotometricSource(
+            id=430, name="RestrictSrc", description="Restricted"
+        )
+        v2_db.add(source)
+        v2_db.flush()
+
+        source_id = source.id
+
+        # Create dataset referencing the source
+        ds = DataSet(
+            values=np.random.normal(0, 1, 100),
+            target=sample_target,
+            observation=sample_observation,
+            photometry_source=source,
+            processing_method_id=ProcessingMethod.UNSPECIFIED_ID,
+        )
+        v2_db.add(ds)
+        v2_db.commit()
+
+        # Attempt to delete via SQL - should fail with RESTRICT
+        # (ORM delete doesn't trigger database-level constraints)
+        with pytest.raises(IntegrityError):
+            v2_db.execute(
+                sa.delete(PhotometricSource).where(
+                    PhotometricSource.id == source_id
+                )
+            )
+            v2_db.commit()
+        v2_db.rollback()
+
+    def test_processing_method_delete_restricted(
+        self,
+        v2_db: orm.Session,
+        sample_target: Target,
+        sample_observation: Observation,
+    ):
+        """Test deleting processing method fails when datasets exist."""
+        # Create photometric source and processing method
+        source = PhotometricSource(
+            id=440, name="PmRestrictSrc", description="PM Restrict"
+        )
+        method = ProcessingMethod(
+            id=440, name="RestrictMeth", description="Restricted"
+        )
+        v2_db.add_all([source, method])
+        v2_db.flush()
+
+        method_id = method.id
+
+        # Create dataset referencing the method
+        ds = DataSet(
+            values=np.random.normal(0, 1, 100),
+            target=sample_target,
+            observation=sample_observation,
+            photometry_source=source,
+            processing_method=method,
+        )
+        v2_db.add(ds)
+        v2_db.commit()
+
+        # Attempt delete via SQL - should fail with RESTRICT
+        with pytest.raises(IntegrityError):
+            v2_db.execute(
+                sa.delete(ProcessingMethod).where(
+                    ProcessingMethod.id == method_id
+                )
+            )
+            v2_db.commit()
+        v2_db.rollback()
+
+
+# -----------------------------------------------------------------------------
+# Composite Key Query Tests
+# -----------------------------------------------------------------------------
+
+
+class TestCompositeKeyQueries:
+    """Tests for DataSet composite key queries."""
+
+    def test_query_by_full_composite_key(
+        self,
+        v2_db: orm.Session,
+        sample_target: Target,
+        sample_observation: Observation,
+        sample_photometric_source: PhotometricSource,
+        sample_processing_method: ProcessingMethod,
+    ):
+        """Test retrieving dataset by all 4 PK components."""
+        # Create dataset
+        ds = DataSet(
+            values=np.random.normal(0, 1, 100),
+            target=sample_target,
+            observation=sample_observation,
+            photometry_source=sample_photometric_source,
+            processing_method=sample_processing_method,
+        )
+        v2_db.add(ds)
+        v2_db.commit()
+
+        # Query by all 4 components
+        result = (
+            v2_db.query(DataSet)
+            .filter(
+                DataSet.observation_id == sample_observation.id,
+                DataSet.target_id == sample_target.id,
+                DataSet.photometric_method_id == sample_photometric_source.id,
+                DataSet.processing_method_id == sample_processing_method.id,
+            )
+            .one_or_none()
+        )
+
+        assert result is not None
+        assert result.target_id == sample_target.id
+
+    def test_query_by_observation_and_target(
+        self,
+        v2_db: orm.Session,
+        sample_target: Target,
+        sample_observation: Observation,
+    ):
+        """Test filtering by observation_id and target_id."""
+        # Create multiple datasets for same observation/target
+        sources = [
+            PhotometricSource(
+                id=500 + i, name=f"CkSrc{i}", description=f"CK {i}"
+            )
+            for i in range(3)
+        ]
+        v2_db.add_all(sources)
+        v2_db.flush()
+
+        for source in sources:
+            ds = DataSet(
+                values=np.random.normal(0, 1, 100),
+                target=sample_target,
+                observation=sample_observation,
+                photometry_source=source,
+                processing_method_id=ProcessingMethod.UNSPECIFIED_ID,
+            )
+            v2_db.add(ds)
+        v2_db.commit()
+
+        # Query by observation + target
+        results = (
+            v2_db.query(DataSet)
+            .filter(
+                DataSet.observation_id == sample_observation.id,
+                DataSet.target_id == sample_target.id,
+            )
+            .all()
+        )
+
+        assert len(results) == 3
+
+    def test_unique_constraint_composite_key(
+        self,
+        v2_db: orm.Session,
+        sample_target: Target,
+        sample_observation: Observation,
+    ):
+        """Test duplicate composite key raises IntegrityError."""
+        # Create photometric source and processing method
+        source = PhotometricSource(
+            id=510, name="UniqSrc", description="Unique"
+        )
+        method = ProcessingMethod(
+            id=510, name="UniqMeth", description="Unique"
+        )
+        v2_db.add_all([source, method])
+        v2_db.flush()
+
+        # Create first dataset
+        ds1 = DataSet(
+            values=np.random.normal(0, 1, 100),
+            target=sample_target,
+            observation=sample_observation,
+            photometry_source=source,
+            processing_method=method,
+        )
+        v2_db.add(ds1)
+        v2_db.commit()
+
+        # Attempt to create duplicate with same composite key
+        ds2 = DataSet(
+            values=np.random.normal(0, 1, 100),
+            target=sample_target,
+            observation=sample_observation,
+            photometry_source=source,
+            processing_method=method,
+        )
+        v2_db.add(ds2)
+
+        with pytest.raises(IntegrityError):
+            v2_db.commit()
+        v2_db.rollback()

--- a/tests/test_mission.py
+++ b/tests/test_mission.py
@@ -281,6 +281,10 @@ class TestMissionConstraints:
             is None
         )
 
+    @pytest.mark.filterwarnings(
+        "ignore:New instance .* conflicts with persistent "
+        "instance:sqlalchemy.exc.SAWarning"
+    )
     def test_mission_uuid_primary_key(self, v2_db: orm.Session):
         """Test UUID primary key behavior."""
         # Create mission without specifying ID

--- a/tests/test_observation.py
+++ b/tests/test_observation.py
@@ -479,7 +479,7 @@ class TestObservationConstraints:
 
         obs_id = observation.id
         qf_id = quality_flags.id
-        tst_id = tst.id
+        tst_obs_id, tst_target_id = tst.observation_id, tst.target_id
 
         # Delete observation
         v2_db.execute(delete(Observation).where(Observation.id == obs_id))
@@ -493,7 +493,9 @@ class TestObservationConstraints:
             v2_db.query(QualityFlagArray).filter_by(id=qf_id).first() is None
         )
         assert (
-            v2_db.query(TargetSpecificTime).filter_by(id=tst_id).first()
+            v2_db.query(TargetSpecificTime)
+            .filter_by(observation_id=tst_obs_id, target_id=tst_target_id)
+            .first()
             is None
         )
 

--- a/tests/test_rich_formatting.py
+++ b/tests/test_rich_formatting.py
@@ -1,0 +1,308 @@
+"""Tests for Rich formatting support on LCDB models.
+
+All tests are pure unit tests — no database session required since we only
+access model attributes set via constructor, not persisted data.
+"""
+
+import uuid
+
+import numpy as np
+from rich.console import Console
+
+from lightcurvedb.core.base_model import LCDBModel, _format_array_summary
+from lightcurvedb.models import (
+    DataSet,
+    DataSetHierarchy,
+    FITSFrame,
+    Instrument,
+    Mission,
+    MissionCatalog,
+    Observation,
+    PhotometricSource,
+    ProcessingMethod,
+    QualityFlagArray,
+    Target,
+    TargetSpecificTime,
+)
+
+# ---------------------------------------------------------------------------
+# TestFormatArraySummary
+# ---------------------------------------------------------------------------
+
+
+class TestFormatArraySummary:
+    def test_none_input(self):
+        assert _format_array_summary(None) == "None"
+
+    def test_non_array_input(self):
+        assert _format_array_summary("hello") == repr("hello")
+
+    def test_empty_array(self):
+        arr = np.array([], dtype=np.int64)
+        assert _format_array_summary(arr) == "[]"
+
+    def test_small_array(self):
+        arr = np.array([1, 2, 3])
+        assert _format_array_summary(arr) == "[1, 2, 3]"
+
+    def test_exactly_six_elements(self):
+        arr = np.array([1, 2, 3, 4, 5, 6])
+        assert _format_array_summary(arr) == "[1, 2, 3, 4, 5, 6]"
+
+    def test_large_int_array(self):
+        arr = np.arange(100, dtype=np.int64)
+        result = _format_array_summary(arr)
+        assert result == "int64[100] range=[0, 99]"
+
+    def test_large_float_array(self):
+        arr = np.linspace(0, 1, 10)
+        result = _format_array_summary(arr)
+        assert "float64[10]" in result
+        assert "range=" in result
+        assert "0.0" in result
+        assert "1.0" in result
+
+
+# ---------------------------------------------------------------------------
+# TestRichReprOverrides
+# ---------------------------------------------------------------------------
+
+
+class TestRichReprOverrides:
+    def test_mission(self):
+        mid = uuid.uuid4()
+        m = Mission(
+            id=mid,
+            name="TESS",
+            description="Test mission",
+            time_unit="day",
+            time_epoch=2457000,
+            time_epoch_scale="tdb",
+            time_epoch_format="jd",
+            time_format_name="btjd",
+        )
+        pairs = list(m.__rich_repr__())
+        assert pairs == [("id", mid), ("name", "TESS")]
+
+    def test_mission_catalog(self):
+        mid = uuid.uuid4()
+        mc = MissionCatalog(
+            id=1,
+            name="TIC",
+            description="TESS Input Catalog",
+            host_mission_id=mid,
+        )
+        pairs = list(mc.__rich_repr__())
+        assert pairs == [("id", 1), ("name", "TIC"), ("mission", mid)]
+
+    def test_target(self):
+        t = Target(id=42, catalog_id=1, name=261136679)
+        pairs = list(t.__rich_repr__())
+        assert pairs == [("id", 42), ("catalog", 1), ("name", 261136679)]
+
+    def test_observation(self):
+        inst_id = uuid.uuid4()
+        o = Observation(
+            id=10,
+            type="observation",
+            cadence_reference=np.arange(10, dtype=np.int64),
+            instrument_id=inst_id,
+        )
+        pairs = list(o.__rich_repr__())
+        assert pairs == [
+            ("id", 10),
+            ("type", "observation"),
+            ("instrument", inst_id),
+        ]
+
+    def test_target_specific_time(self):
+        tst = TargetSpecificTime(
+            observation_id=1,
+            target_id=42,
+            barycentric_julian_dates=np.array([1.0, 2.0]),
+        )
+        pairs = list(tst.__rich_repr__())
+        assert pairs == [("observation_id", 1), ("target_id", 42)]
+
+    def test_instrument_without_parent(self):
+        inst_id = uuid.uuid4()
+        inst = Instrument(
+            id=inst_id, name="Camera 1", properties={}, parent_id=None
+        )
+        pairs = list(inst.__rich_repr__())
+        assert len(pairs) == 2
+        assert pairs == [("id", inst_id), ("name", "Camera 1")]
+
+    def test_instrument_with_parent(self):
+        inst_id = uuid.uuid4()
+        parent_id = uuid.uuid4()
+        inst = Instrument(
+            id=inst_id, name="Camera 1", properties={}, parent_id=parent_id
+        )
+        pairs = list(inst.__rich_repr__())
+        assert len(pairs) == 3
+        assert pairs == [
+            ("id", inst_id),
+            ("name", "Camera 1"),
+            ("parent", parent_id),
+        ]
+
+    def test_quality_flag_array_without_target(self):
+        qfa = QualityFlagArray(
+            id=5,
+            type="base_quality_flag",
+            observation_id=1,
+            target_id=None,
+            quality_flags=np.array([0, 1], dtype=np.int32),
+        )
+        pairs = list(qfa.__rich_repr__())
+        assert len(pairs) == 3
+        assert pairs == [
+            ("id", 5),
+            ("type", "base_quality_flag"),
+            ("obs", 1),
+        ]
+
+    def test_quality_flag_array_with_target(self):
+        qfa = QualityFlagArray(
+            id=5,
+            type="base_quality_flag",
+            observation_id=1,
+            target_id=42,
+            quality_flags=np.array([0, 1], dtype=np.int32),
+        )
+        pairs = list(qfa.__rich_repr__())
+        assert len(pairs) == 4
+        assert pairs == [
+            ("id", 5),
+            ("type", "base_quality_flag"),
+            ("obs", 1),
+            ("target", 42),
+        ]
+
+    def test_fits_frame(self):
+        ff = FITSFrame(
+            id=100,
+            type="basefits",
+            cadence=12345,
+            observation_id=1,
+            simple=True,
+            bitpix=16,
+            bscale=1.0,
+            bzero=0.0,
+            naxis=2,
+            naxis_values=[2048, 2048],
+            extended=True,
+        )
+        pairs = list(ff.__rich_repr__())
+        assert pairs == [
+            ("id", 100),
+            ("type", "basefits"),
+            ("cadence", 12345),
+            ("obs", 1),
+        ]
+
+    def test_photometric_source(self):
+        ps = PhotometricSource(
+            id=0, name="unspecified", description="No source specified"
+        )
+        pairs = list(ps.__rich_repr__())
+        assert pairs == [("id", 0), ("name", "unspecified")]
+
+    def test_processing_method(self):
+        pm = ProcessingMethod(
+            id=1, name="detrend-v1", description="Detrending v1"
+        )
+        pairs = list(pm.__rich_repr__())
+        assert pairs == [("id", 1), ("name", "detrend-v1")]
+
+    def test_dataset_hierarchy(self):
+        dsh = DataSetHierarchy(
+            source_observation_id=1,
+            source_target_id=10,
+            source_photometric_method_id=0,
+            source_processing_method_id=0,
+            child_observation_id=2,
+            child_target_id=20,
+            child_photometric_method_id=0,
+            child_processing_method_id=0,
+        )
+        pairs = list(dsh.__rich_repr__())
+        assert pairs == [
+            ("source_obs", 1),
+            ("source_target", 10),
+            ("child_obs", 2),
+            ("child_target", 20),
+        ]
+
+    def test_dataset(self):
+        ds = DataSet(
+            observation_id=1,
+            target_id=42,
+            photometric_method_id=0,
+            processing_method_id=0,
+            values=np.array([1.0, 2.0]),
+        )
+        pairs = list(ds.__rich_repr__())
+        assert pairs == [
+            ("obs", 1),
+            ("target", 42),
+            ("phot", 0),
+            ("proc", 0),
+        ]
+
+
+# ---------------------------------------------------------------------------
+# TestRichConsoleProtocol
+# ---------------------------------------------------------------------------
+
+
+class TestRichConsoleProtocol:
+    def _render(self, model) -> str:
+        console = Console(width=120, force_terminal=True)
+        with console.capture() as capture:
+            console.print(model)
+        return capture.get()
+
+    def test_photometric_source_console_output(self):
+        ps = PhotometricSource(
+            id=1, name="aperture", description="Simple aperture photometry"
+        )
+        output = self._render(ps)
+        assert "PhotometricSource" in output
+        assert "id" in output
+        assert "name" in output
+
+    def test_dataset_console_output_with_arrays(self):
+        ds = DataSet(
+            observation_id=1,
+            target_id=42,
+            photometric_method_id=0,
+            processing_method_id=0,
+            values=np.arange(100, dtype=np.float64),
+            errors=None,
+        )
+        output = self._render(ds)
+        assert "DataSet" in output
+        assert "observation_id" in output
+        assert "values" in output
+        # Array should be summarized, not printed in full
+        assert "float64[100]" in output
+
+
+# ---------------------------------------------------------------------------
+# TestDefaultRichRepr
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultRichRepr:
+    def test_base_rich_repr_yields_primary_keys(self):
+        """The base LCDBModel.__rich_repr__ yields PK columns."""
+        ps = PhotometricSource(id=99, name="test", description="Test source")
+        # Call the base class method directly, bypassing the override
+        pairs = list(LCDBModel.__rich_repr__(ps))
+        # PhotometricSource has a single PK column: id
+        assert ("id", 99) in pairs
+        # The base method should not yield non-PK columns
+        keys = [k for k, _ in pairs]
+        assert "name" not in keys

--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -511,7 +511,7 @@ class TestTargetConstraints:
         v2_db.commit()
 
         target_id = target.id
-        tst_id = tst.id
+        tst_obs_id = tst.observation_id
 
         # Delete target - related objects should handle this appropriately
         v2_db.execute(delete(Target).where(Target.id == target.id))
@@ -522,7 +522,9 @@ class TestTargetConstraints:
 
         # Verify TargetSpecificTime is deleted via cascade
         assert (
-            v2_db.query(TargetSpecificTime).filter_by(id=tst_id).first()
+            v2_db.query(TargetSpecificTime)
+            .filter_by(observation_id=tst_obs_id, target_id=target_id)
+            .first()
             is None
         )
 

--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -15,7 +15,6 @@ from lightcurvedb.models import (
     Target,
     TargetSpecificTime,
 )
-from lightcurvedb.models.dataset import DataSet
 
 
 class TestTargetBasics:
@@ -521,7 +520,11 @@ class TestTargetConstraints:
         # Verify target is deleted
         assert v2_db.query(Target).filter_by(id=target_id).first() is None
 
-        assert v2_db.query(DataSet).filter_by(id=tst_id).first() is None
+        # Verify TargetSpecificTime is deleted via cascade
+        assert (
+            v2_db.query(TargetSpecificTime).filter_by(id=tst_id).first()
+            is None
+        )
 
 
 class TestTargetQueries:

--- a/tests/test_target_specific_time.py
+++ b/tests/test_target_specific_time.py
@@ -62,7 +62,7 @@ class TestTargetSpecificTimeBasics:
         v2_db.commit()
 
         # Verify creation
-        assert tst.id is not None
+        assert tst.observation_id == observation.id
         assert tst.target_id == target.id
         assert tst.observation_id == observation.id
         assert np.array_equal(tst.barycentric_julian_dates, bjd_array)
@@ -618,8 +618,7 @@ class TestTargetSpecificTimeConstraints:
         v2_db.add(tst)
         v2_db.commit()
 
-        tst_id = tst.id
-        target_id = target.id
+        obs_id, target_id = tst.observation_id, tst.target_id
 
         # Delete target
         v2_db.delete(target)
@@ -630,7 +629,9 @@ class TestTargetSpecificTimeConstraints:
 
         # Verify TST is also deleted (cascade)
         assert (
-            v2_db.query(TargetSpecificTime).filter_by(id=tst_id).first()
+            v2_db.query(TargetSpecificTime)
+            .filter_by(observation_id=obs_id, target_id=target_id)
+            .first()
             is None
         )
 
@@ -672,7 +673,7 @@ class TestTargetSpecificTimeConstraints:
         v2_db.add(tst)
         v2_db.commit()
 
-        tst_id = tst.id
+        target_id = tst.target_id
         obs_id = observation.id
 
         # Delete observation
@@ -684,7 +685,9 @@ class TestTargetSpecificTimeConstraints:
 
         # Verify TST is also deleted (cascade)
         assert (
-            v2_db.query(TargetSpecificTime).filter_by(id=tst_id).first()
+            v2_db.query(TargetSpecificTime)
+            .filter_by(observation_id=obs_id, target_id=target_id)
+            .first()
             is None
         )
 


### PR DESCRIPTION
## Summary

- **PostgreSQL LIST partitioning** for DataSet by `observation_id` with composite primary keys and sentinel values, enabling scale to billions of rows
- **Rich formatting** support added to all SQLAlchemy models with `__repr__` methods and Rich `__rich__` rendering
- **DataSet hierarchy** system for tracking data lineage and processing provenance
- **New model methods**: `align_to_observation`, `align_to_reference` on DataSet, `query_for_instrument` on Instrument, `register_mission_time_epoch` on Mission
- **Testing improvements**: comprehensive property-based and unit tests for all new features, coverage reporting, Docker test environment updates
- **CI enhancements**: commitizen for conventional commits, updated semantic-release and test workflows
- **Cleanup**: removed unused exceptions module, simplified scope module, fixed SQLAlchemy 2.x compatibility issues

## Versions included

2.2.1-beta.1 → 2.3.0-beta.1 → 2.3.0-beta.2 → 3.0.0-beta.1 through 3.0.0-beta.6

## Test plan

- [x] CI passes on all supported Python versions (3.11-3.12)
- [x] Docker-based integration tests pass against PostgreSQL
- [x] Dataset partitioning tests validate composite PK and LIST partitioning behavior
- [x] Rich formatting renders correctly for all models
- [x] Existing tests remain green with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)