### PR TITLE
Release 3.1.0: Target aliasing and documentation fixes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,10 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
+
+# The pinned black/flake8 releases predate Python 3.14 and crash under it, so
+# run the Python-based hooks on 3.12 (a supported target, see noxfile.py).
+default_language_version:
+    python: python3.12
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.3.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,13 @@ services:
       dockerfile: ./Dockerfile
     volumes:
       - .:/testing
+      # Keep generated build artifacts off the macOS bind mount: writing
+      # egg-info / wheel build trees over Docker Desktop's file share raises
+      # EDEADLK ([Errno 35] Resource deadlock avoided). Anonymous volumes give
+      # them native Linux-backed paths instead.
+      - /testing/src/lightcurvedb.egg-info
+      - /testing/build
+      - /testing/docs/build
     working_dir: /testing
     command: tail -f /dev/null
     environment:

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -16,12 +16,16 @@ These are available directly from ``import lightcurvedb``:
 
 .. autodata:: lightcurvedb.__version__
    :no-value:
+   :no-index:
 
 .. autofunction:: lightcurvedb.db_from_config
+   :no-index:
 
 .. autodata:: lightcurvedb.db
+   :no-index:
 
 .. autodata:: lightcurvedb.LCDB_Session
+   :no-index:
 
 Models
 ------
@@ -35,16 +39,19 @@ Mission & Catalog
    :members:
    :exclude-members: metadata, registry
    :show-inheritance:
+   :no-index:
 
 .. autoclass:: lightcurvedb.models.MissionCatalog
    :members:
    :exclude-members: metadata, registry
    :show-inheritance:
+   :no-index:
 
 .. autoclass:: lightcurvedb.models.Target
    :members:
    :exclude-members: metadata, registry
    :show-inheritance:
+   :no-index:
 
 Instrument
 ~~~~~~~~~~
@@ -53,6 +60,7 @@ Instrument
    :members:
    :exclude-members: metadata, registry
    :show-inheritance:
+   :no-index:
 
 Observation & Time
 ~~~~~~~~~~~~~~~~~~
@@ -61,11 +69,13 @@ Observation & Time
    :members:
    :exclude-members: metadata, registry
    :show-inheritance:
+   :no-index:
 
 .. autoclass:: lightcurvedb.models.TargetSpecificTime
    :members:
    :exclude-members: metadata, registry
    :show-inheritance:
+   :no-index:
 
 Frames
 ~~~~~~
@@ -74,6 +84,7 @@ Frames
    :members:
    :exclude-members: metadata, registry
    :show-inheritance:
+   :no-index:
 
 Processing
 ~~~~~~~~~~
@@ -82,11 +93,13 @@ Processing
    :members:
    :exclude-members: metadata, registry, name
    :show-inheritance:
+   :no-index:
 
 .. autoclass:: lightcurvedb.models.ProcessingMethod
    :members:
    :exclude-members: metadata, registry, name
    :show-inheritance:
+   :no-index:
 
 Data Products
 ~~~~~~~~~~~~~
@@ -95,11 +108,13 @@ Data Products
    :members:
    :exclude-members: metadata, registry
    :show-inheritance:
+   :no-index:
 
 .. autoclass:: lightcurvedb.models.DataSetHierarchy
    :members:
    :exclude-members: metadata, registry
    :show-inheritance:
+   :no-index:
 
 Quality Flags
 ~~~~~~~~~~~~~
@@ -108,6 +123,7 @@ Quality Flags
    :members:
    :exclude-members: metadata, registry, created_on
    :show-inheritance:
+   :no-index:
 
 Base Class & Mixins
 -------------------
@@ -118,12 +134,15 @@ when extending the ORM.
 .. autoclass:: lightcurvedb.core.base_model.LCDBModel
    :members: __repr__, __rich_repr__, __rich_console__
    :show-inheritance:
+   :no-index:
 
 .. autoclass:: lightcurvedb.core.base_model.CreatedOnMixin
    :members:
+   :no-index:
 
 .. autoclass:: lightcurvedb.core.base_model.NameAndDescriptionMixin
    :members:
+   :no-index:
 
 Custom Types
 ~~~~~~~~~~~~
@@ -131,20 +150,25 @@ Custom Types
 .. autoclass:: lightcurvedb.core.types.NumpyArrayType
    :members: process_result_value, process_bind_param, coerce_compared_value
    :show-inheritance:
+   :no-index:
 
 Connection & Session Management
 -------------------------------
 
 .. autofunction:: lightcurvedb.core.connection.db_from_config
+   :no-index:
 
 .. autofunction:: lightcurvedb.core.connection.configure_engine
+   :no-index:
 
 .. autodata:: lightcurvedb.core.connection.LCDB_Session
+   :no-index:
 
 I/O & Pipeline
 --------------
 
 .. autofunction:: lightcurvedb.io.db_scope
+   :no-index:
 
 Utilities
 ---------
@@ -153,17 +177,22 @@ Iteration Helpers
 ~~~~~~~~~~~~~~~~~
 
 .. autofunction:: lightcurvedb.util.iter.chunkify
+   :no-index:
 
 .. autofunction:: lightcurvedb.util.iter.eq_partitions
+   :no-index:
 
 Path Context Extraction
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 .. autofunction:: lightcurvedb.util.contexts.REGISTER
+   :no-index:
 
 .. autofunction:: lightcurvedb.util.contexts.extract_pdo_path_context
+   :no-index:
 
 Constants
 ~~~~~~~~~
 
 .. autodata:: lightcurvedb.util.constants.DEFAULT_CONFIG_PATH
+   :no-index:

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -5,10 +5,6 @@ This page lists all public classes, functions, and constants available to
 developers using LightcurveDB. Internal (underscore-prefixed) members are
 omitted.
 
-.. contents:: Sections
-   :local:
-   :depth: 1
-
 Top-Level Exports
 -----------------
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -1,0 +1,169 @@
+API Reference
+=============
+
+This page lists all public classes, functions, and constants available to
+developers using LightcurveDB. Internal (underscore-prefixed) members are
+omitted.
+
+.. contents:: Sections
+   :local:
+   :depth: 1
+
+Top-Level Exports
+-----------------
+
+These are available directly from ``import lightcurvedb``:
+
+.. autodata:: lightcurvedb.__version__
+   :no-value:
+
+.. autofunction:: lightcurvedb.db_from_config
+
+.. autodata:: lightcurvedb.db
+
+.. autodata:: lightcurvedb.LCDB_Session
+
+Models
+------
+
+All models are importable from ``lightcurvedb.models``.
+
+Mission & Catalog
+~~~~~~~~~~~~~~~~~
+
+.. autoclass:: lightcurvedb.models.Mission
+   :members:
+   :exclude-members: metadata, registry
+   :show-inheritance:
+
+.. autoclass:: lightcurvedb.models.MissionCatalog
+   :members:
+   :exclude-members: metadata, registry
+   :show-inheritance:
+
+.. autoclass:: lightcurvedb.models.Target
+   :members:
+   :exclude-members: metadata, registry
+   :show-inheritance:
+
+Instrument
+~~~~~~~~~~
+
+.. autoclass:: lightcurvedb.models.Instrument
+   :members:
+   :exclude-members: metadata, registry
+   :show-inheritance:
+
+Observation & Time
+~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: lightcurvedb.models.Observation
+   :members:
+   :exclude-members: metadata, registry
+   :show-inheritance:
+
+.. autoclass:: lightcurvedb.models.TargetSpecificTime
+   :members:
+   :exclude-members: metadata, registry
+   :show-inheritance:
+
+Frames
+~~~~~~
+
+.. autoclass:: lightcurvedb.models.FITSFrame
+   :members:
+   :exclude-members: metadata, registry
+   :show-inheritance:
+
+Processing
+~~~~~~~~~~
+
+.. autoclass:: lightcurvedb.models.PhotometricSource
+   :members:
+   :exclude-members: metadata, registry, name
+   :show-inheritance:
+
+.. autoclass:: lightcurvedb.models.ProcessingMethod
+   :members:
+   :exclude-members: metadata, registry, name
+   :show-inheritance:
+
+Data Products
+~~~~~~~~~~~~~
+
+.. autoclass:: lightcurvedb.models.DataSet
+   :members:
+   :exclude-members: metadata, registry
+   :show-inheritance:
+
+.. autoclass:: lightcurvedb.models.DataSetHierarchy
+   :members:
+   :exclude-members: metadata, registry
+   :show-inheritance:
+
+Quality Flags
+~~~~~~~~~~~~~
+
+.. autoclass:: lightcurvedb.models.QualityFlagArray
+   :members:
+   :exclude-members: metadata, registry, created_on
+   :show-inheritance:
+
+Base Class & Mixins
+-------------------
+
+These are importable from ``lightcurvedb.core.base_model`` and are useful
+when extending the ORM.
+
+.. autoclass:: lightcurvedb.core.base_model.LCDBModel
+   :members: __repr__, __rich_repr__, __rich_console__
+   :show-inheritance:
+
+.. autoclass:: lightcurvedb.core.base_model.CreatedOnMixin
+   :members:
+
+.. autoclass:: lightcurvedb.core.base_model.NameAndDescriptionMixin
+   :members:
+
+Custom Types
+~~~~~~~~~~~~
+
+.. autoclass:: lightcurvedb.core.types.NumpyArrayType
+   :members: process_result_value, process_bind_param, coerce_compared_value
+   :show-inheritance:
+
+Connection & Session Management
+-------------------------------
+
+.. autofunction:: lightcurvedb.core.connection.db_from_config
+
+.. autofunction:: lightcurvedb.core.connection.configure_engine
+
+.. autodata:: lightcurvedb.core.connection.LCDB_Session
+
+I/O & Pipeline
+--------------
+
+.. autofunction:: lightcurvedb.io.db_scope
+
+Utilities
+---------
+
+Iteration Helpers
+~~~~~~~~~~~~~~~~~
+
+.. autofunction:: lightcurvedb.util.iter.chunkify
+
+.. autofunction:: lightcurvedb.util.iter.eq_partitions
+
+Path Context Extraction
+~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autofunction:: lightcurvedb.util.contexts.REGISTER
+
+.. autofunction:: lightcurvedb.util.contexts.extract_pdo_path_context
+
+Constants
+~~~~~~~~~
+
+.. autodata:: lightcurvedb.util.constants.DEFAULT_CONFIG_PATH

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -93,6 +93,7 @@ Submodule Documentation
     connecting
     schema
     models
+    api
     db/db
     util/utils
 

--- a/docs/source/schema.rst
+++ b/docs/source/schema.rst
@@ -134,23 +134,23 @@ Entity Relationship Diagram
        }
 
        DataSet {
-           int observation_id PK-FK "partition key"
-           int target_id PK-FK
-           int photometric_method_id PK-FK "0=unspecified"
-           int processing_method_id PK-FK "0=unspecified"
+           int observation_id PK "partition key, FK"
+           int target_id PK "FK"
+           int photometric_method_id PK "FK, 0=unspecified"
+           int processing_method_id PK "FK, 0=unspecified"
            array values
            array errors
        }
 
        DataSetHierarchy {
-           int source_observation_id PK-FK
-           int source_target_id PK-FK
-           int source_photometric_method_id PK-FK
-           int source_processing_method_id PK-FK
-           int child_observation_id PK-FK
-           int child_target_id PK-FK
-           int child_photometric_method_id PK-FK
-           int child_processing_method_id PK-FK
+           int source_observation_id PK "FK"
+           int source_target_id PK "FK"
+           int source_photometric_method_id PK "FK"
+           int source_processing_method_id PK "FK"
+           int child_observation_id PK "FK"
+           int child_target_id PK "FK"
+           int child_photometric_method_id PK "FK"
+           int child_processing_method_id PK "FK"
        }
 
        TargetSpecificTime {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ where = ["src"]
 
 [project]
 name = "lightcurvedb"
-version = "3.0.0-beta.12"
+version = "3.1.0-beta.1"
 description = "SQLAlchemy models and APIs for storing lightcurve timeseries."
 authors = [{name="William Fong", email="willfong@mit.edu"}]
 readme = "README.rst"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ where = ["src"]
 
 [project]
 name = "lightcurvedb"
-version = "3.0.0-beta.10"  # Managed by python-semantic-release
+version = "3.0.0-beta.11"  # Managed by python-semantic-release
 description = "SQLAlchemy models and APIs for storing lightcurve timeseries."
 authors = [{name="William Fong", email="willfong@mit.edu"}]
 readme = "README.rst"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ where = ["src"]
 
 [project]
 name = "lightcurvedb"
-version = "3.0.0-beta.11"  # Managed by python-semantic-release
+version = "3.0.0-beta.11"
 description = "SQLAlchemy models and APIs for storing lightcurve timeseries."
 authors = [{name="William Fong", email="willfong@mit.edu"}]
 readme = "README.rst"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ where = ["src"]
 
 [project]
 name = "lightcurvedb"
-version = "3.0.0-beta.8"  # Managed by python-semantic-release
+version = "3.0.0-beta.9"  # Managed by python-semantic-release
 description = "SQLAlchemy models and APIs for storing lightcurve timeseries."
 authors = [{name="William Fong", email="willfong@mit.edu"}]
 readme = "README.rst"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ where = ["src"]
 
 [project]
 name = "lightcurvedb"
-version = "3.0.0-beta.7"  # Managed by python-semantic-release
+version = "3.0.0-beta.8"  # Managed by python-semantic-release
 description = "SQLAlchemy models and APIs for storing lightcurve timeseries."
 authors = [{name="William Fong", email="willfong@mit.edu"}]
 readme = "README.rst"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ where = ["src"]
 
 [project]
 name = "lightcurvedb"
-version = "3.0.0-beta.9"  # Managed by python-semantic-release
+version = "3.0.0-beta.10"  # Managed by python-semantic-release
 description = "SQLAlchemy models and APIs for storing lightcurve timeseries."
 authors = [{name="William Fong", email="willfong@mit.edu"}]
 readme = "README.rst"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ where = ["src"]
 
 [project]
 name = "lightcurvedb"
-version = "3.0.0-beta.11"
+version = "3.0.0-beta.12"
 description = "SQLAlchemy models and APIs for storing lightcurve timeseries."
 authors = [{name="William Fong", email="willfong@mit.edu"}]
 readme = "README.rst"

--- a/src/lightcurvedb/__init__.py
+++ b/src/lightcurvedb/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.0.0-beta.9"  # Managed by python-semantic-release
+__version__ = "3.0.0-beta.10"  # Managed by python-semantic-release
 
 from lightcurvedb.core.connection import LCDB_Session, db, db_from_config
 

--- a/src/lightcurvedb/__init__.py
+++ b/src/lightcurvedb/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.0.0-beta.10"  # Managed by python-semantic-release
+__version__ = "3.0.0-beta.11"  # Managed by python-semantic-release
 
 from lightcurvedb.core.connection import LCDB_Session, db, db_from_config
 

--- a/src/lightcurvedb/__init__.py
+++ b/src/lightcurvedb/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.0.0-beta.11"
+__version__ = "3.0.0-beta.12"
 
 from lightcurvedb.core.connection import LCDB_Session, db, db_from_config
 

--- a/src/lightcurvedb/__init__.py
+++ b/src/lightcurvedb/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.0.0-beta.7"  # Managed by python-semantic-release
+__version__ = "3.0.0-beta.8"  # Managed by python-semantic-release
 
 from lightcurvedb.core.connection import LCDB_Session, db, db_from_config
 

--- a/src/lightcurvedb/__init__.py
+++ b/src/lightcurvedb/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.0.0-beta.8"  # Managed by python-semantic-release
+__version__ = "3.0.0-beta.9"  # Managed by python-semantic-release
 
 from lightcurvedb.core.connection import LCDB_Session, db, db_from_config
 

--- a/src/lightcurvedb/__init__.py
+++ b/src/lightcurvedb/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.0.0-beta.11"  # Managed by python-semantic-release
+__version__ = "3.0.0-beta.11"
 
 from lightcurvedb.core.connection import LCDB_Session, db, db_from_config
 

--- a/src/lightcurvedb/__init__.py
+++ b/src/lightcurvedb/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.0.0-beta.12"
+__version__ = "3.1.0-beta.1"
 
 from lightcurvedb.core.connection import LCDB_Session, db, db_from_config
 

--- a/src/lightcurvedb/core/types.py
+++ b/src/lightcurvedb/core/types.py
@@ -63,7 +63,7 @@ class NumpyArrayType(TypeDecorator):
     - BigInteger -> np.int64 (64-bit signed integer)
     - REAL -> np.float32 (32-bit float, single precision)
     - Float -> np.float64 (64-bit float, double precision)
-    - Boolean -> np.bool_ (boolean type)
+    - Boolean -> ``np.bool_`` (boolean type)
 
     Special cases:
     - np.int8 maps to SmallInteger (PostgreSQL has no TINYINT)
@@ -177,7 +177,7 @@ class NumpyArrayType(TypeDecorator):
           → np.int64
         - REAL: 6 decimal digits precision → np.float32
         - Float (DOUBLE PRECISION): 15 decimal digits precision → np.float64
-        - Boolean: true/false → np.bool_
+        - Boolean: true/false → ``np.bool_``
 
         Types not supported:
         - int8: PostgreSQL has no TINYINT, using SmallInteger

--- a/src/lightcurvedb/models/__init__.py
+++ b/src/lightcurvedb/models/__init__.py
@@ -8,7 +8,7 @@ from .frame import FITSFrame
 from .instrument import Instrument
 from .observation import Observation, TargetSpecificTime
 from .quality_flag import QualityFlagArray
-from .target import Mission, MissionCatalog, Target
+from .target import Alias, Mission, MissionCatalog, Target
 
 __all__ = [
     "FITSFrame",
@@ -16,6 +16,7 @@ __all__ = [
     "PhotometricSource",
     "ProcessingMethod",
     "Observation",
+    "Alias",
     "Mission",
     "MissionCatalog",
     "Target",

--- a/src/lightcurvedb/models/target.py
+++ b/src/lightcurvedb/models/target.py
@@ -190,6 +190,38 @@ class Target(LCDBModel):
     catalog: orm.Mapped["MissionCatalog"] = orm.relationship(
         back_populates="targets"
     )
+    # An alias pairing is symmetric and the two columns carry no order, so a
+    # given target may occupy either one. These collections cover both
+    # positions; use the ``aliases`` / ``aliased_targets`` properties below for
+    # a position-agnostic view.
+    _alias_links_as_target: orm.Mapped[list["Alias"]] = orm.relationship(
+        foreign_keys="Alias.target_id",
+        back_populates="target",
+        cascade="all, delete-orphan",
+        passive_deletes=True,
+    )
+    _alias_links_as_counterpart: orm.Mapped[list["Alias"]] = orm.relationship(
+        foreign_keys="Alias.counterpart_id",
+        back_populates="counterpart",
+        cascade="all, delete-orphan",
+        passive_deletes=True,
+    )
+
+    @property
+    def aliases(self) -> list["Alias"]:
+        """Every Alias row this target participates in, either position."""
+        return [
+            *self._alias_links_as_target,
+            *self._alias_links_as_counterpart,
+        ]
+
+    @property
+    def aliased_targets(self) -> list["Target"]:
+        """The other target in each of this target's alias pairings."""
+        return [link.counterpart for link in self._alias_links_as_target] + [
+            link.target for link in self._alias_links_as_counterpart
+        ]
+
     datasets: orm.Mapped[list["DataSet"]] = orm.relationship(
         back_populates="target"
     )
@@ -214,3 +246,105 @@ class Target(LCDBModel):
         yield "id", self.id
         yield "catalog", self.catalog_id
         yield "name", self.name
+
+
+class Alias(LCDBModel):
+    """
+    A symmetric cross-identification between two targets.
+
+    Alias records that two catalog entries are believed to refer to the same
+    astronomical object. Aliasing is most often a one-to-one match across
+    catalogs (the same star with two catalog IDs), but it also captures the
+    ambiguous cases: a single older entry that a modern catalog resolves into
+    several distinct objects, or several entries later found to be one object.
+
+    The relation is **symmetric** -- "A aliases B" is identical to "B aliases
+    A" -- so each pairing is stored exactly once and the two columns carry no
+    direction or ordering. It is deliberately **not transitive**: each row
+    asserts only the single correspondence it names. In a split, target X may
+    alias both Y and Z without implying Y aliases Z.
+
+    Attributes
+    ----------
+    id : int
+        Primary key identifier
+    target_id : int
+        Foreign key to one member of the pairing
+    counterpart_id : int
+        Foreign key to the other member of the pairing
+    target : Target
+        The target referenced by ``target_id``
+    counterpart : Target
+        The target referenced by ``counterpart_id``
+
+    Notes
+    -----
+    The two columns are interchangeable; neither is privileged and their values
+    must not be assumed to follow any catalog ordering. A self-reference
+    ``CheckConstraint`` forbids a target aliasing itself, and a unique index
+    over ``least(target_id, counterpart_id), greatest(...)`` collapses the two
+    storable orderings of a pair to a single row -- least/greatest is only a
+    deterministic dedup key, not a meaningful order.
+
+    To enumerate a target's aliases regardless of column, prefer
+    :attr:`Target.aliases` / :attr:`Target.aliased_targets`.
+    """
+
+    __tablename__ = "alias"
+    __table_args__ = (
+        sa.CheckConstraint(
+            "target_id <> counterpart_id", name="alias_no_self_reference"
+        ),
+        # Treat (a, b) and (b, a) as the same alias by deduplicating on the
+        # unordered pair. least()/greatest() canonicalize purely for the index
+        # key and imply no ordering of the targets themselves. Expressed as
+        # text() so the index can live inline without resolved Column objects.
+        sa.Index(
+            "uq_alias_unordered_pair",
+            sa.text("least(target_id, counterpart_id)"),
+            sa.text("greatest(target_id, counterpart_id)"),
+            unique=True,
+        ),
+    )
+
+    id: orm.Mapped[int] = orm.mapped_column(sa.BigInteger, primary_key=True)
+    target_id: orm.Mapped[int] = orm.mapped_column(
+        sa.ForeignKey(Target.id, ondelete="CASCADE", onupdate="CASCADE")
+    )
+    counterpart_id: orm.Mapped[int] = orm.mapped_column(
+        sa.ForeignKey(Target.id, ondelete="CASCADE", onupdate="CASCADE")
+    )
+
+    # Relationships
+    target: orm.Mapped["Target"] = orm.relationship(
+        foreign_keys=[target_id],
+        back_populates="_alias_links_as_target",
+    )
+    counterpart: orm.Mapped["Target"] = orm.relationship(
+        foreign_keys=[counterpart_id],
+        back_populates="_alias_links_as_counterpart",
+    )
+
+    @classmethod
+    def between(cls, a: "Target", b: "Target") -> "Alias":
+        """
+        Build an alias pairing two targets, in either argument order.
+
+        The pair is stored as given; the unique index treats ``(a, b)`` and
+        ``(b, a)`` as the same row. Raises ``ValueError`` if the same target is
+        passed twice, since a target cannot alias itself.
+        """
+        if a.id == b.id:
+            raise ValueError("a target cannot be aliased to itself")
+        return cls(target=a, counterpart=b)
+
+    def __repr__(self) -> str:
+        return (
+            f"<Alias(id={self.id!r}, target={self.target_id!r}, "
+            f"counterpart={self.counterpart_id!r})>"
+        )
+
+    def __rich_repr__(self):
+        yield "id", self.id
+        yield "target", self.target_id
+        yield "counterpart", self.counterpart_id

--- a/tests/test_alias.py
+++ b/tests/test_alias.py
@@ -1,0 +1,267 @@
+"""Test the Alias symmetric cross-identification model.
+
+Aliasing pairs two targets that are believed to refer to the same
+astronomical object. The relation is symmetric (no direction) and explicitly
+*not* transitive -- in a catalog split, one target may alias several others
+without those others aliasing each other.
+"""
+
+import uuid
+
+import pytest
+from hypothesis import assume, given
+from sqlalchemy import delete, exc, orm
+
+from lightcurvedb.models import Alias, Mission, MissionCatalog, Target
+
+from .strategies import tess as tess_st
+
+
+def _make_catalog(
+    session: orm.Session, name: str, catalog_name: str = "CAT"
+) -> MissionCatalog:
+    """Persist a mission + catalog and return the catalog."""
+    mission = Mission(
+        id=uuid.uuid4(),
+        name=name,
+        description="Alias test mission",
+        time_unit="day",
+        time_epoch=0.0,
+        time_epoch_scale="tdb",
+        time_epoch_format="jd",
+        time_format_name=name,  # unique per mission
+    )
+    catalog = MissionCatalog(
+        host_mission=mission, name=catalog_name, description="Alias catalog"
+    )
+    session.add_all([mission, catalog])
+    session.flush()
+    return catalog
+
+
+def _make_target(
+    session: orm.Session, catalog: MissionCatalog, name: int
+) -> Target:
+    """Persist and return a target in the given catalog."""
+    target = Target(catalog=catalog, name=name)
+    session.add(target)
+    session.flush()
+    return target
+
+
+class TestAliasBetween:
+    """Pure-logic tests for the Alias.between constructor."""
+
+    @given(tess_st.tic_ids())
+    def test_rejects_self_alias(self, identifier: int):
+        """A target cannot be aliased to itself."""
+        target = Target(id=identifier, name=identifier)
+        with pytest.raises(ValueError):
+            Alias.between(target, target)
+
+    @given(tess_st.tic_ids(), tess_st.tic_ids())
+    def test_rejects_distinct_objects_sharing_id(self, id_a: int, id_b: int):
+        """Two targets with the same id are the same object, so disallowed."""
+        a = Target(id=id_a, name=id_a)
+        b = Target(id=id_a, name=id_b)  # deliberately reuse id_a
+        with pytest.raises(ValueError):
+            Alias.between(a, b)
+
+    @given(tess_st.tic_ids(), tess_st.tic_ids())
+    def test_links_both_targets(self, id_a: int, id_b: int):
+        """between() wires up both relationship sides for a valid pair."""
+        assume(id_a != id_b)
+        a = Target(id=id_a, name=id_a)
+        b = Target(id=id_b, name=id_b)
+
+        alias = Alias.between(a, b)
+
+        # Membership is order-agnostic; the pairing holds both targets.
+        assert {alias.target, alias.counterpart} == {a, b}
+
+
+class TestAliasBasics:
+    """Create aliases and navigate them symmetrically."""
+
+    def test_create_alias(self, v2_db: orm.Session):
+        """A persisted alias links two existing targets."""
+        catalog = _make_catalog(v2_db, "CREATE_MISSION")
+        a = _make_target(v2_db, catalog, 1001)
+        b = _make_target(v2_db, catalog, 1002)
+
+        alias = Alias.between(a, b)
+        v2_db.add(alias)
+        v2_db.commit()
+
+        assert alias.id is not None
+        assert {alias.target_id, alias.counterpart_id} == {a.id, b.id}
+
+    def test_symmetric_navigation(self, v2_db: orm.Session):
+        """aliased_targets returns the other member regardless of column."""
+        catalog = _make_catalog(v2_db, "NAV_MISSION")
+        a = _make_target(v2_db, catalog, 2001)
+        b = _make_target(v2_db, catalog, 2002)
+        c = _make_target(v2_db, catalog, 2003)
+
+        # a sits on the `target` side of both pairings.
+        v2_db.add_all([Alias.between(a, b), Alias.between(a, c)])
+        v2_db.commit()
+        for t in (a, b, c):
+            v2_db.refresh(t)
+
+        assert {t.id for t in a.aliased_targets} == {b.id, c.id}
+        assert {t.id for t in b.aliased_targets} == {a.id}
+        assert {t.id for t in c.aliased_targets} == {a.id}
+        assert len(a.aliases) == 2
+
+    def test_navigation_independent_of_argument_order(
+        self, v2_db: orm.Session
+    ):
+        """Either member reaches the other, whichever column it landed in."""
+        catalog = _make_catalog(v2_db, "ORDER_MISSION")
+        a = _make_target(v2_db, catalog, 3001)
+        b = _make_target(v2_db, catalog, 3002)
+
+        # Build with `a` deliberately on the counterpart side.
+        v2_db.add(Alias.between(b, a))
+        v2_db.commit()
+        v2_db.refresh(a)
+        v2_db.refresh(b)
+
+        assert [t.id for t in a.aliased_targets] == [b.id]
+        assert [t.id for t in b.aliased_targets] == [a.id]
+
+
+class TestAliasConstraints:
+    """Database-level guarantees: no self-aliases, no duplicate pairs, FKs."""
+
+    def test_self_reference_rejected_by_db(self, v2_db: orm.Session):
+        """The CHECK constraint rejects a row pointing a target at itself."""
+        catalog = _make_catalog(v2_db, "SELF_MISSION")
+        a = _make_target(v2_db, catalog, 4001)
+
+        v2_db.add(Alias(target_id=a.id, counterpart_id=a.id))
+        with pytest.raises(exc.IntegrityError):
+            v2_db.commit()
+        v2_db.rollback()
+
+    def test_reversed_pair_is_duplicate(self, v2_db: orm.Session):
+        """(b, a) is the same unordered pair as (a, b) and is rejected."""
+        catalog = _make_catalog(v2_db, "REVERSE_MISSION")
+        a = _make_target(v2_db, catalog, 5001)
+        b = _make_target(v2_db, catalog, 5002)
+
+        v2_db.add(Alias(target_id=a.id, counterpart_id=b.id))
+        v2_db.commit()
+
+        v2_db.add(Alias(target_id=b.id, counterpart_id=a.id))
+        with pytest.raises(exc.IntegrityError):
+            v2_db.commit()
+        v2_db.rollback()
+
+    def test_identical_pair_is_duplicate(self, v2_db: orm.Session):
+        """The same ordered pair cannot be stored twice."""
+        catalog = _make_catalog(v2_db, "DUP_MISSION")
+        a = _make_target(v2_db, catalog, 6001)
+        b = _make_target(v2_db, catalog, 6002)
+
+        v2_db.add(Alias(target_id=a.id, counterpart_id=b.id))
+        v2_db.commit()
+
+        v2_db.add(Alias(target_id=a.id, counterpart_id=b.id))
+        with pytest.raises(exc.IntegrityError):
+            v2_db.commit()
+        v2_db.rollback()
+
+    def test_distinct_pairs_allowed(self, v2_db: orm.Session):
+        """Different unordered pairs sharing a target coexist."""
+        catalog = _make_catalog(v2_db, "DISTINCT_MISSION")
+        a = _make_target(v2_db, catalog, 7001)
+        b = _make_target(v2_db, catalog, 7002)
+        c = _make_target(v2_db, catalog, 7003)
+
+        v2_db.add_all([Alias.between(a, b), Alias.between(a, c)])
+        v2_db.commit()  # should not raise
+
+        assert v2_db.query(Alias).count() == 2
+
+    def test_foreign_key_constraint(self, v2_db: orm.Session):
+        """An alias referencing a non-existent target is rejected."""
+        v2_db.add(Alias(target_id=999999, counterpart_id=888888))
+        with pytest.raises(exc.IntegrityError):
+            v2_db.commit()
+        v2_db.rollback()
+
+    def test_cascade_on_target_delete(self, v2_db: orm.Session):
+        """Deleting a target removes its alias rows via ON DELETE CASCADE."""
+        catalog = _make_catalog(v2_db, "CASCADE_MISSION")
+        a = _make_target(v2_db, catalog, 8001)
+        b = _make_target(v2_db, catalog, 8002)
+
+        v2_db.add(Alias(target_id=a.id, counterpart_id=b.id))
+        v2_db.commit()
+        assert v2_db.query(Alias).count() == 1
+
+        # DELETE at the SQL level exercises the DB FK cascade, not ORM cascade.
+        v2_db.execute(delete(Target).where(Target.id == a.id))
+        v2_db.commit()
+
+        assert v2_db.query(Alias).count() == 0
+
+
+class TestAliasSemantics:
+    """Encode the domain cases that motivated the symmetric, loose model."""
+
+    def test_cross_catalog_alias(self, v2_db: orm.Session):
+        """The common case: the same object under two catalog ids."""
+        mission = Mission(
+            id=uuid.uuid4(),
+            name="XCAT_MISSION",
+            description="Cross-catalog mission",
+            time_unit="day",
+            time_epoch=0.0,
+            time_epoch_scale="tdb",
+            time_epoch_format="jd",
+            time_format_name="XCAT_MISSION",
+        )
+        old_catalog = MissionCatalog(
+            host_mission=mission, name="OLD", description="Older catalog"
+        )
+        new_catalog = MissionCatalog(
+            host_mission=mission, name="NEW", description="Modern catalog"
+        )
+        v2_db.add_all([mission, old_catalog, new_catalog])
+        v2_db.flush()
+
+        old_entry = _make_target(v2_db, old_catalog, 12345)
+        new_entry = _make_target(v2_db, new_catalog, 12345)
+
+        v2_db.add(Alias.between(old_entry, new_entry))
+        v2_db.commit()
+        v2_db.refresh(old_entry)
+
+        (counterpart,) = old_entry.aliased_targets
+        assert counterpart.id == new_entry.id
+        assert counterpart.catalog_id != old_entry.catalog_id
+
+    def test_split_is_not_transitive(self, v2_db: orm.Session):
+        """A target split into several does not alias them to each other.
+
+        Old entry X resolves into modern entries Y and Z. X aliases both, but
+        Y and Z are genuinely distinct objects and must not appear as aliases
+        of one another.
+        """
+        catalog = _make_catalog(v2_db, "SPLIT_MISSION")
+        x = _make_target(v2_db, catalog, 9001)
+        y = _make_target(v2_db, catalog, 9002)
+        z = _make_target(v2_db, catalog, 9003)
+
+        v2_db.add_all([Alias.between(x, y), Alias.between(x, z)])
+        v2_db.commit()
+        for t in (x, y, z):
+            v2_db.refresh(t)
+
+        assert {t.id for t in x.aliased_targets} == {y.id, z.id}
+        # Non-transitive: Y and Z never see each other.
+        assert z.id not in {t.id for t in y.aliased_targets}
+        assert y.id not in {t.id for t in z.aliased_targets}


### PR DESCRIPTION
## Summary

- **New feature — symmetric Alias model** (#36) for cross-catalog target identification. Self-referential many-to-many between `Target` rows, symmetric and explicitly non-transitive (correctly handles catalog splits and merges). Dedup via a functional unique index on `least()/greatest()` with no `Target.id` ordering imposed; CHECK forbids self-aliases; FK `ON DELETE CASCADE`. `Target.aliases` / `Target.aliased_targets` give position-agnostic navigation. 14 new tests in `tests/test_alias.py` (property-based for the `between()` constructor, example-based for DB constraints and the cross-catalog and non-transitive-split semantics).
- **Documentation** — new API reference page listing all public classes and functions; fixed Mermaid `erDiagram` syntax, duplicate-object warnings, the `np.bool_` RST error, and the manual `contents` directive incompatible with the Furo theme.
- **Test infrastructure** — `docker-compose.yml` now shadows generated build artifacts (`src/lightcurvedb.egg-info`, `build/`, `docs/build/`) with anonymous volumes so the in-container `nox` run no longer hits `[Errno 35] Resource deadlock avoided` on Docker Desktop's macOS file share.
- **Tooling** — `.pre-commit-config.yaml` pins the python-based hook interpreter to 3.12; the pinned black 22.6.0 / flake8 5.0.3 crash under Python 3.14.

## Versions included

3.0.0-beta.8 → 3.0.0-beta.9 → 3.0.0-beta.10 → 3.0.0-beta.11 → 3.0.0-beta.12

(Per `pyproject.toml` semantic-release config: one `feat` commit since 3.0.0 produces a minor bump → **3.1.0**.)

## Migration note

For the Alembic migration that adds `alias`: the functional unique index (`uq_alias_unordered_pair`) on `least(target_id, counterpart_id), greatest(...)` and the CHECK (`alias_no_self_reference`) need explicit `op.create_index` / `op.create_check_constraint` — Alembic autogenerate does not handle expression indexes reliably.

## Test plan

- [x] CI green on `feature/target-aliasing` (commitlint, build, tests 3.11, tests 3.12)
- [x] Full nox suite passes in container: 238 tests (224 prior + 14 new)
- [x] Docs build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)