### PR TITLE
feat(models): astrophysical parameters — ParameterKind + AstroParameter with name-keyed access

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -49,6 +49,21 @@ Mission & Catalog
    :show-inheritance:
    :no-index:
 
+Astrophysical Parameters
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: lightcurvedb.models.ParameterKind
+   :members:
+   :exclude-members: metadata, registry
+   :show-inheritance:
+   :no-index:
+
+.. autoclass:: lightcurvedb.models.AstroParameter
+   :members:
+   :exclude-members: metadata, registry
+   :show-inheritance:
+   :no-index:
+
 Instrument
 ~~~~~~~~~~
 

--- a/docs/source/bulk_parameters.rst
+++ b/docs/source/bulk_parameters.rst
@@ -1,0 +1,311 @@
+===========================
+Writing Parameters at Scale
+===========================
+
+This guide shows how to load astrophysical parameters for very large target
+sets -- on the order of tens of millions of targets -- efficiently and
+idempotently. The running example is **25 million targets**, each carrying a
+handful of measured quantities (say ~20), i.e. roughly **500 million**
+:class:`~lightcurvedb.models.AstroParameter` rows. The technique scales
+linearly: halve the parameters-per-target and you halve the rows.
+
+The data model in one minute
+============================
+
+Two models matter here (see :doc:`schema` for the full picture):
+
+* :class:`~lightcurvedb.models.ParameterKind` -- a **named quantity-kind**. Its
+  ``name`` is unique (the keyword, e.g. ``"effective_temperature"``) and
+  ``unit_str`` holds the astropy unit (e.g. ``"K"``). This is a *tiny* lookup
+  table: one row per distinct quantity, a few dozen rows in practice.
+* :class:`~lightcurvedb.models.AstroParameter` -- one measured ``value`` (with
+  asymmetric ``upper_error`` / ``lower_error``) for a target, referencing a
+  :class:`~lightcurvedb.models.Target` (``target_id``) and a
+  :class:`~lightcurvedb.models.ParameterKind` (``kind_id``). This is the *large*
+  table. A ``UniqueConstraint`` on ``(target_id, kind_id)`` means a target holds
+  at most one parameter per kind.
+
+Because the parameter *name* lives once per kind in ``parameter_kind`` and each
+``astro_parameter`` row only carries a 4-byte ``kind_id``, the name costs
+essentially nothing per row at scale -- which is exactly why bulk loading is
+cheap.
+
+.. note::
+
+   ``AstroParameter.name`` is **read-only** -- it mirrors ``kind.name`` through
+   an association proxy. You never write it; you set the name on the
+   :class:`~lightcurvedb.models.ParameterKind`. Likewise, ``value`` is stored
+   *verbatim* in the kind's unit: the database performs no unit conversion, so
+   express the value in the kind's unit before writing it.
+
+Why SQLAlchemy Core
+===================
+
+The ORM's unit-of-work (identity map, autoflush, per-object bookkeeping) is
+convenient for a handful of objects but ruinous for hundreds of millions. For
+bulk loads, drive inserts with SQLAlchemy **Core** and an *executemany* list of
+plain dicts -- no model instances are created, and the work goes to the driver
+in one round trip per batch.
+
+The examples assume you have a ``session`` (a SQLAlchemy
+:class:`~sqlalchemy.orm.Session`). See :doc:`connecting` for the
+``db_scope`` decorator and other ways to obtain one.
+
+Step 1 -- Establish the parameter-kind vocabulary
+=================================================
+
+There is no built-in get-or-create for kinds, but the set is small and fixed,
+so upsert it once and read back a ``{name: id}`` map. ``on_conflict_do_nothing``
+on the unique ``name`` makes this idempotent across re-runs.
+
+.. code-block:: python
+    :linenos:
+
+    import astropy.units as u
+    from sqlalchemy import select
+    from sqlalchemy.dialects.postgresql import insert as pg_insert
+
+    from lightcurvedb.models import ParameterKind
+
+    # (name, astropy unit) for every quantity you will write.
+    KIND_SPECS = [
+        ("effective_temperature", u.K),
+        ("radius", u.solRad),
+        ("mass", u.solMass),
+        ("distance", u.pc),
+        # ...
+    ]
+
+    def ensure_kinds(session, kind_specs):
+        """Idempotently create the kinds and return a {name: id} map."""
+        session.execute(
+            pg_insert(ParameterKind).on_conflict_do_nothing(
+                index_elements=["name"]
+            ),
+            [{"name": name, "unit_str": str(unit)} for name, unit in kind_specs],
+        )
+        session.commit()
+        return dict(
+            session.execute(
+                select(ParameterKind.name, ParameterKind.id)
+            ).all()
+        )
+
+``str(u.K)`` yields ``"K"`` -- the same string
+:meth:`ParameterKind.reflect_astropy_unit
+<lightcurvedb.models.ParameterKind.reflect_astropy_unit>` would store -- so the
+unit round-trips through :meth:`ParameterKind.as_unit
+<lightcurvedb.models.ParameterKind.as_unit>` on read.
+
+Step 2 -- Resolve target ids
+============================
+
+``AstroParameter.target_id`` is a foreign key, so the
+:class:`~lightcurvedb.models.Target` rows must already exist. If your source
+data identifies targets by catalog name, build a lookup once:
+
+.. code-block:: python
+    :linenos:
+
+    from lightcurvedb.models import Target
+
+    def target_id_map(session, catalog_id):
+        """Map a catalog's target names to their database ids."""
+        rows = session.execute(
+            select(Target.name, Target.id).where(
+                Target.catalog_id == catalog_id
+            )
+        ).all()
+        return {name: id_ for name, id_ in rows}
+
+At 25M targets this map is a few hundred MB in memory; if that is too much,
+resolve ids in chunks aligned to your input batches instead of all at once.
+
+Step 3 -- Bulk-insert the parameters
+====================================
+
+Feed Core a list of plain dicts. **Omit** ``id`` (the database assigns it from a
+sequence) and **omit** ``name`` (it is the read-only proxy). Each dict carries
+only the real columns:
+
+.. code-block:: python
+    :linenos:
+
+    from sqlalchemy import insert
+    from lightcurvedb.models import AstroParameter
+
+    batch = [
+        {
+            "target_id": 1001,
+            "kind_id": kind_ids["effective_temperature"],
+            "value": 5772.0,
+            "upper_error": 50.0,
+            "lower_error": 40.0,
+        },
+        # ... up to ~batch_size rows ...
+    ]
+    session.execute(insert(AstroParameter), batch)
+    session.commit()
+
+Generate ``batch`` lazily from your input stream -- never materialise all 500M
+dicts at once.
+
+Idempotent re-runs (upsert)
+===========================
+
+A plain ``insert`` raises on a duplicate ``(target_id, kind_id)``. To make loads
+safely re-runnable -- updating values in place rather than failing -- use the
+PostgreSQL ``ON CONFLICT`` form keyed on the unique constraint:
+
+.. code-block:: python
+    :linenos:
+
+    from sqlalchemy.dialects.postgresql import insert as pg_insert
+
+    stmt = pg_insert(AstroParameter)
+    stmt = stmt.on_conflict_do_update(
+        index_elements=["target_id", "kind_id"],
+        set_={
+            "value": stmt.excluded.value,
+            "upper_error": stmt.excluded.upper_error,
+            "lower_error": stmt.excluded.lower_error,
+        },
+    )
+    session.execute(stmt, batch)
+    session.commit()
+
+Use :meth:`~sqlalchemy.dialects.postgresql.Insert.on_conflict_do_nothing`
+instead if existing values should be left untouched. Both forms work with the
+*executemany* batch list shown above.
+
+Batching and commit cadence
+===========================
+
+* **Batch size.** ~10k-50k rows per ``execute`` is a good range. Larger batches
+  amortise round trips but use more memory and lengthen each statement.
+* **Commit cadence.** Commit every few batches (e.g. every 10) rather than once
+  at the very end. This bounds transaction size, WAL growth, and lock
+  duration, and lets a failed run resume near where it stopped (the upsert makes
+  re-processing a committed batch a no-op).
+* **One session, streamed input.** Reuse a single session for the whole job and
+  generate batches from an iterator so memory stays flat. The global
+  ``LCDB_Session`` is configured with ``expire_on_commit=False``, so committing
+  mid-loop will not trigger reloads.
+
+Reading parameters back
+=======================
+
+Once loaded, a target's parameters are reachable by keyword:
+
+.. code-block:: python
+    :linenos:
+
+    target = session.get(Target, 1001)
+
+    # dict view keyed by parameter name
+    teff = target.parameters_by_name["effective_temperature"]
+    teff.value            # 5772.0
+
+    # __getitem__ returns an astropy Quantity (value * unit)
+    target["effective_temperature"]      # <Quantity 5772. K>
+    teff.as_quantity()                   # equivalent
+
+.. note::
+
+   ``parameters_by_name`` is a view loaded from the database, so refresh or
+   re-fetch the target after a bulk write (``session.refresh(target)``) before
+   reading it in the same session.
+
+Pitfalls
+========
+
+.. warning::
+
+   Never assign ``AstroParameter.name``. It is an association proxy onto
+   ``kind.name``; writing it would rename the *shared*
+   :class:`~lightcurvedb.models.ParameterKind` for every target that uses it.
+   Set names on the kind, in Step 1.
+
+* **Duplicate keys within a batch.** Two rows with the same
+  ``(target_id, kind_id)`` in one ``execute`` abort the whole batch unless you
+  use the ``ON CONFLICT`` form. De-duplicate your input.
+* **Kinds cannot be deleted while in use.** ``kind_id`` is ``ON DELETE
+  RESTRICT``; curate the vocabulary up front rather than deleting kinds later.
+* **Targets first.** ``target_id`` is a foreign key -- load
+  :class:`~lightcurvedb.models.Target` rows before their parameters.
+* **Not partitioned.** ``astro_parameter`` is a plain table. The design handles
+  hundreds of millions of rows comfortably; at the multi-billion-row scale you
+  may later want PostgreSQL partitioning (out of scope here).
+
+Putting it together
+===================
+
+A complete, re-runnable loader. Input ``rows`` is any iterable of
+``(target_id, kind_name, value, upper_error, lower_error)`` tuples:
+
+.. code-block:: python
+    :linenos:
+
+    from itertools import islice
+
+    import astropy.units as u
+    from sqlalchemy import select
+    from sqlalchemy.dialects.postgresql import insert as pg_insert
+
+    from lightcurvedb.io.pipeline import db_scope
+    from lightcurvedb.models import AstroParameter, ParameterKind
+
+    KIND_SPECS = [
+        ("effective_temperature", u.K),
+        ("radius", u.solRad),
+        ("mass", u.solMass),
+    ]
+
+    def _batched(iterable, n):
+        it = iter(iterable)
+        while chunk := list(islice(it, n)):
+            yield chunk
+
+    @db_scope()
+    def bulk_write_parameters(session, rows, batch_size=20_000):
+        # Step 1: kinds + {name: id}
+        session.execute(
+            pg_insert(ParameterKind).on_conflict_do_nothing(
+                index_elements=["name"]
+            ),
+            [{"name": n, "unit_str": str(u_)} for n, u_ in KIND_SPECS],
+        )
+        kind_id = dict(
+            session.execute(
+                select(ParameterKind.name, ParameterKind.id)
+            ).all()
+        )
+
+        # Steps 3 + upsert: stream batches
+        stmt = pg_insert(AstroParameter)
+        stmt = stmt.on_conflict_do_update(
+            index_elements=["target_id", "kind_id"],
+            set_={
+                "value": stmt.excluded.value,
+                "upper_error": stmt.excluded.upper_error,
+                "lower_error": stmt.excluded.lower_error,
+            },
+        )
+
+        for i, chunk in enumerate(_batched(rows, batch_size), start=1):
+            session.execute(
+                stmt,
+                [
+                    {
+                        "target_id": target_id,
+                        "kind_id": kind_id[kind_name],
+                        "value": value,
+                        "upper_error": upper,
+                        "lower_error": lower,
+                    }
+                    for target_id, kind_name, value, upper, lower in chunk
+                ],
+            )
+            if i % 10 == 0:
+                session.commit()
+        session.commit()

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -91,6 +91,7 @@ Submodule Documentation
 
     installation
     connecting
+    bulk_parameters
     schema
     models
     api

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -76,3 +76,14 @@ Target Models
 .. autoclass:: lightcurvedb.models.Target
    :members:
    :show-inheritance:
+
+Astrophysical Parameters
+------------------------
+
+.. autoclass:: lightcurvedb.models.ParameterKind
+   :members:
+   :show-inheritance:
+
+.. autoclass:: lightcurvedb.models.AstroParameter
+   :members:
+   :show-inheritance:

--- a/src/lightcurvedb/models/__init__.py
+++ b/src/lightcurvedb/models/__init__.py
@@ -8,7 +8,14 @@ from .frame import FITSFrame
 from .instrument import Instrument
 from .observation import Observation, TargetSpecificTime
 from .quality_flag import QualityFlagArray
-from .target import Alias, Mission, MissionCatalog, Target
+from .target import (
+    Alias,
+    AstroParameter,
+    AstroUnit,
+    Mission,
+    MissionCatalog,
+    Target,
+)
 
 __all__ = [
     "FITSFrame",
@@ -17,6 +24,8 @@ __all__ = [
     "ProcessingMethod",
     "Observation",
     "Alias",
+    "AstroUnit",
+    "AstroParameter",
     "Mission",
     "MissionCatalog",
     "Target",

--- a/src/lightcurvedb/models/__init__.py
+++ b/src/lightcurvedb/models/__init__.py
@@ -11,9 +11,9 @@ from .quality_flag import QualityFlagArray
 from .target import (
     Alias,
     AstroParameter,
-    AstroUnit,
     Mission,
     MissionCatalog,
+    ParameterKind,
     Target,
 )
 
@@ -24,7 +24,7 @@ __all__ = [
     "ProcessingMethod",
     "Observation",
     "Alias",
-    "AstroUnit",
+    "ParameterKind",
     "AstroParameter",
     "Mission",
     "MissionCatalog",

--- a/src/lightcurvedb/models/target.py
+++ b/src/lightcurvedb/models/target.py
@@ -4,6 +4,7 @@ from functools import lru_cache
 from typing import TYPE_CHECKING
 
 import sqlalchemy as sa
+from sqlalchemy.ext import associationproxy as ap
 from astropy import time
 from astropy import units as u
 from sqlalchemy import orm
@@ -168,13 +169,19 @@ class Target(LCDBModel):
         Time series specific to this target
     quality_flag_arrays : list[QualityFlagArray]
         Target-specific quality flags
-    astro_parameters : list[AstroParameter]
+    parameters : list[AstroParameter]
         Astrophysical parameters measured for this target
+    parameters_by_name : dict[str, AstroParameter]
+        Read-only view of ``parameters`` keyed by parameter name
 
     Notes
     -----
     The combination of catalog_id and name must be unique,
     ensuring no duplicate targets within a catalog.
+
+    Indexing a target by parameter name -- ``target["effective_temperature"]``
+    -- returns that parameter as an astropy quantity (see
+    :meth:`__getitem__`).
     """
 
     __tablename__ = "target"
@@ -237,10 +244,20 @@ class Target(LCDBModel):
     quality_flag_arrays: orm.Mapped[list["QualityFlagArray"]] = (
         orm.relationship(back_populates="target")
     )
-    astro_parameters: orm.Mapped[list["AstroParameter"]] = orm.relationship(
+    parameters: orm.Mapped[list["AstroParameter"]] = orm.relationship(
         back_populates="target",
         cascade="all, delete-orphan",
         passive_deletes=True,
+    )
+    # Read-only dict view of the same rows, keyed by AstroParameter.name
+    # (unique per target). viewonly so writes go through ``astro_parameters``;
+    # keys are read from loaded rows, sidestepping the keyed-collection
+    # transient-key pitfall.
+    parameters_by_name: orm.Mapped[dict[str, "AstroParameter"]] = (
+        orm.relationship(
+            collection_class=orm.attribute_keyed_dict("name"),
+            viewonly=True,
+        )
     )
 
     def __repr__(self) -> str:
@@ -253,6 +270,33 @@ class Target(LCDBModel):
         yield "id", self.id
         yield "catalog", self.catalog_id
         yield "name", self.name
+
+    def __getitem__(self, key: str) -> u.Quantity:
+        """
+        Return a measured parameter as an astropy quantity by name.
+
+        Enables ``target["effective_temperature"]``: looks the parameter up
+        in :attr:`parameters_by_name` and returns
+        :meth:`AstroParameter.as_quantity`.
+
+        Parameters
+        ----------
+        key : str
+            The parameter name (i.e. its unit's name).
+
+        Returns
+        -------
+        astropy.units.Quantity
+            ``value * unit`` for the named parameter.
+
+        Raises
+        ------
+        KeyError
+            If the target has no parameter with that name.
+        """
+        if key not in self.parameters_by_name:
+            raise KeyError(f"{key!r} is not a parameter of {self!r}")
+        return self.parameters_by_name[key].as_quantity()
 
 
 class Alias(LCDBModel):
@@ -373,7 +417,9 @@ class AstroUnit(LCDBModel):
     id : int
         Primary key identifier.
     name : str
-        Human-readable label for the unit (e.g., "effective temperature").
+        Unique label identifying the quantity (e.g.
+        ``"effective_temperature"``). Serves as the keyword for
+        :attr:`AstroParameter.name` and ``Target.parameters_by_name``.
     unit_str : str
         The unit's astropy generic string form, e.g. ``"K"`` or ``"m / s"``.
     description : str
@@ -388,6 +434,11 @@ class AstroUnit(LCDBModel):
     composites can exceed float64 range during astropy's own decomposition;
     such units fall outside the intended scope.
 
+    ``name`` is unique: each row defines one named quantity-kind (with
+    ``unit_str`` giving that quantity's unit), which is how parameters are
+    keyed on a target. Distinct kinds may share a ``unit_str`` (e.g. two
+    temperatures both in ``"K"``).
+
     Examples
     --------
     >>> from astropy import units as u
@@ -400,7 +451,7 @@ class AstroUnit(LCDBModel):
 
     __tablename__ = "astro_unit"
     id: orm.Mapped[int] = orm.mapped_column(primary_key=True)
-    name: orm.Mapped[str]
+    name: orm.Mapped[str] = orm.mapped_column(index=True, unique=True)
     unit_str: orm.Mapped[str]
     description: orm.Mapped[str] = orm.mapped_column(sa.TEXT, default="")
 
@@ -498,6 +549,10 @@ class AstroParameter(LCDBModel):
     ----------
     id : int
         Primary key identifier.
+    name : str
+        Read-only. The parameter kind, mirrored from ``unit.name`` (e.g.
+        ``"effective_temperature"``). Assign the kind on the
+        :class:`AstroUnit`, not here.
     value : float
         The parameter value, expressed in the linked unit.
     upper_error : float
@@ -519,8 +574,10 @@ class AstroParameter(LCDBModel):
     responsibility: the model stores and returns both verbatim and performs
     no unit conversion or scale normalization.
 
-    The unique constraint on ``(target_id, unit_id)`` permits at most one
-    parameter per unit on a given target.
+    The unique constraint on ``(target_id, unit_id)`` permits one parameter
+    per unit on a given target. Because each :class:`AstroUnit` has a unique
+    ``name``, that is equivalently one parameter per name -- so ``name``
+    identifies a parameter within its target.
     """
 
     __tablename__ = "astro_parameter"
@@ -532,6 +589,9 @@ class AstroParameter(LCDBModel):
     )
 
     id: orm.Mapped[int] = orm.mapped_column(sa.BigInteger, primary_key=True)
+    # Read-only view of the parameter kind; mirrors unit.name. Assign the kind
+    # on the AstroUnit -- writing here would rename the shared unit.
+    name: ap.AssociationProxy[str] = ap.association_proxy("unit", "name")
     value: orm.Mapped[float]
     upper_error: orm.Mapped[float]
     lower_error: orm.Mapped[float]
@@ -546,7 +606,7 @@ class AstroParameter(LCDBModel):
 
     # Relationships
     target: orm.Mapped["Target"] = orm.relationship(
-        back_populates="astro_parameters",
+        back_populates="parameters",
     )
     unit: orm.Mapped["AstroUnit"] = orm.relationship(
         back_populates="parameters",
@@ -571,12 +631,14 @@ class AstroParameter(LCDBModel):
 
     def __repr__(self) -> str:
         return (
-            f"<AstroParameter(id={self.id!r}, value={self.value!r}, "
-            f"target={self.target_id!r}, unit={self.unit_id!r})>"
+            f"<AstroParameter(id={self.id!r}, name={self.name!r}, "
+            f"value={self.value!r}, target={self.target_id!r}, "
+            f"unit={self.unit_id!r})>"
         )
 
     def __rich_repr__(self):
         yield "id", self.id
+        yield "name", self.name
         yield "value", self.value
         yield "target", self.target_id
         yield "unit", self.unit_id

--- a/src/lightcurvedb/models/target.py
+++ b/src/lightcurvedb/models/target.py
@@ -168,6 +168,8 @@ class Target(LCDBModel):
         Time series specific to this target
     quality_flag_arrays : list[QualityFlagArray]
         Target-specific quality flags
+    astro_parameters : list[AstroParameter]
+        Astrophysical parameters measured for this target
 
     Notes
     -----
@@ -234,6 +236,11 @@ class Target(LCDBModel):
     )
     quality_flag_arrays: orm.Mapped[list["QualityFlagArray"]] = (
         orm.relationship(back_populates="target")
+    )
+    astro_parameters: orm.Mapped[list["AstroParameter"]] = orm.relationship(
+        back_populates="target",
+        cascade="all, delete-orphan",
+        passive_deletes=True,
     )
 
     def __repr__(self) -> str:
@@ -371,6 +378,8 @@ class AstroUnit(LCDBModel):
         The unit's astropy generic string form, e.g. ``"K"`` or ``"m / s"``.
     description : str
         Optional free-text description; defaults to an empty string.
+    parameters : list[AstroParameter]
+        Parameters expressed in this unit (shared lookup; not owned).
 
     Notes
     -----
@@ -394,6 +403,12 @@ class AstroUnit(LCDBModel):
     name: orm.Mapped[str]
     unit_str: orm.Mapped[str]
     description: orm.Mapped[str] = orm.mapped_column(sa.TEXT, default="")
+
+    # Relationships
+    parameters: orm.Mapped[list["AstroParameter"]] = orm.relationship(
+        lazy=True,
+        back_populates="unit",
+    )
 
     def as_unit(self):
         """
@@ -458,6 +473,17 @@ class AstroUnit(LCDBModel):
             case _:
                 raise NotImplementedError
 
+    def __repr__(self) -> str:
+        return (
+            f"<AstroUnit(id={self.id!r}, name={self.name!r}, "
+            f"unit_str={self.unit_str!r})>"
+        )
+
+    def __rich_repr__(self):
+        yield "id", self.id
+        yield "name", self.name
+        yield "unit_str", self.unit_str
+
 
 class AstroParameter(LCDBModel):
     """
@@ -482,6 +508,10 @@ class AstroParameter(LCDBModel):
         Foreign key to the :class:`Target` this parameter describes.
     unit_id : int
         Foreign key to the :class:`AstroUnit` giving the value's unit.
+    target : Target
+        The target this parameter describes.
+    unit : AstroUnit
+        The unit the value is expressed in.
 
     Notes
     -----
@@ -506,8 +536,47 @@ class AstroParameter(LCDBModel):
     upper_error: orm.Mapped[float]
     lower_error: orm.Mapped[float]
     target_id: orm.Mapped[int] = orm.mapped_column(
-        sa.ForeignKey(Target.id), index=True
+        sa.ForeignKey(Target.id, ondelete="CASCADE", onupdate="CASCADE"),
+        index=True,
     )
     unit_id: orm.Mapped[int] = orm.mapped_column(
-        sa.ForeignKey(AstroUnit.id), index=True
+        sa.ForeignKey(AstroUnit.id, ondelete="RESTRICT"),
+        index=True,
     )
+
+    # Relationships
+    target: orm.Mapped["Target"] = orm.relationship(
+        back_populates="astro_parameters",
+    )
+    unit: orm.Mapped["AstroUnit"] = orm.relationship(
+        back_populates="parameters",
+    )
+
+    def as_quantity(self) -> u.Quantity:
+        """
+        Combine ``value`` with its unit into an astropy quantity.
+
+        Returns
+        -------
+        astropy.units.Quantity
+            ``self.value * self.unit.as_unit()``, using ``value`` verbatim
+            with no scale conversion.
+
+        Notes
+        -----
+        Requires the :attr:`unit` relationship; an attached instance
+        lazy-loads it. Raises ``AttributeError`` if :attr:`unit` is ``None``.
+        """
+        return self.value * self.unit.as_unit()
+
+    def __repr__(self) -> str:
+        return (
+            f"<AstroParameter(id={self.id!r}, value={self.value!r}, "
+            f"target={self.target_id!r}, unit={self.unit_id!r})>"
+        )
+
+    def __rich_repr__(self):
+        yield "id", self.id
+        yield "value", self.value
+        yield "target", self.target_id
+        yield "unit", self.unit_id

--- a/src/lightcurvedb/models/target.py
+++ b/src/lightcurvedb/models/target.py
@@ -401,11 +401,11 @@ class Alias(LCDBModel):
         yield "counterpart", self.counterpart_id
 
 
-class AstroUnit(LCDBModel):
+class ParameterKind(LCDBModel):
     """
     A physical unit, stored as its astropy string representation.
 
-    AstroUnit persists an :class:`astropy.units.UnitBase` by its generic
+    ParameterKind persists an :class:`astropy.units.UnitBase` by its generic
     string form (``unit_str``) and rebuilds the live unit on demand via
     :meth:`as_unit`. Storing the string keeps arbitrary named and composite
     units (``m``, ``mag``, ``erg / (cm2 s)``) representable without a fixed
@@ -442,14 +442,14 @@ class AstroUnit(LCDBModel):
     Examples
     --------
     >>> from astropy import units as u
-    >>> unit = AstroUnit.reflect_astropy_unit(u.m / u.s, name="velocity")
+    >>> unit = ParameterKind.reflect_astropy_unit(u.m / u.s, name="velocity")
     >>> unit.unit_str
     'm / s'
     >>> unit.as_unit() == u.m / u.s
     True
     """
 
-    __tablename__ = "astro_unit"
+    __tablename__ = "parameter_kind"
     id: orm.Mapped[int] = orm.mapped_column(primary_key=True)
     name: orm.Mapped[str] = orm.mapped_column(index=True, unique=True)
     unit_str: orm.Mapped[str]
@@ -458,7 +458,7 @@ class AstroUnit(LCDBModel):
     # Relationships
     parameters: orm.Mapped[list["AstroParameter"]] = orm.relationship(
         lazy=True,
-        back_populates="unit",
+        back_populates="kind",
     )
 
     def as_unit(self):
@@ -476,9 +476,9 @@ class AstroUnit(LCDBModel):
     @classmethod
     def reflect_astropy_unit(
         cls, astropy_unit_or_quantity: u.UnitBase | u.Quantity, **kwargs
-    ) -> "AstroUnit":
+    ) -> "ParameterKind":
         """
-        Build an :class:`AstroUnit` from an astropy unit or quantity.
+        Build an :class:`ParameterKind` from an astropy unit or quantity.
 
         The unit is serialized with ``str()``. For a quantity only its unit
         is stored; the scalar magnitude is discarded.
@@ -494,7 +494,7 @@ class AstroUnit(LCDBModel):
 
         Returns
         -------
-        AstroUnit
+        ParameterKind
             An unsaved instance with ``unit_str`` set from the input.
 
         Raises
@@ -512,7 +512,7 @@ class AstroUnit(LCDBModel):
         Examples
         --------
         >>> from astropy import units as u
-        >>> AstroUnit.reflect_astropy_unit(u.K, name="temp").unit_str
+        >>> ParameterKind.reflect_astropy_unit(u.K, name="temp").unit_str
         'K'
         """
         match astropy_unit_or_quantity:
@@ -526,7 +526,7 @@ class AstroUnit(LCDBModel):
 
     def __repr__(self) -> str:
         return (
-            f"<AstroUnit(id={self.id!r}, name={self.name!r}, "
+            f"<ParameterKind(id={self.id!r}, name={self.name!r}, "
             f"unit_str={self.unit_str!r})>"
         )
 
@@ -541,18 +541,18 @@ class AstroParameter(LCDBModel):
     A measured astrophysical quantity for a target, with asymmetric errors.
 
     AstroParameter stores a scalar ``value`` alongside independent upper and
-    lower uncertainties and a reference to the :class:`AstroUnit` the value is
-    expressed in. The split errors capture the common ``value (+upper,
-    -lower)`` reporting convention used in the literature.
+    lower uncertainties and a reference to the :class:`ParameterKind`
+    (named quantity) it measures. The split errors capture the common
+    ``value (+upper, -lower)`` reporting convention used in the literature.
 
     Attributes
     ----------
     id : int
         Primary key identifier.
     name : str
-        Read-only. The parameter kind, mirrored from ``unit.name`` (e.g.
-        ``"effective_temperature"``). Assign the kind on the
-        :class:`AstroUnit`, not here.
+        Read-only. The parameter kind, mirrored from ``kind.name`` (e.g.
+        ``"effective_temperature"``). Assign it on the
+        :class:`ParameterKind`, not here.
     value : float
         The parameter value, expressed in the linked unit.
     upper_error : float
@@ -561,12 +561,12 @@ class AstroParameter(LCDBModel):
         Lower (negative-direction) uncertainty on ``value``.
     target_id : int
         Foreign key to the :class:`Target` this parameter describes.
-    unit_id : int
-        Foreign key to the :class:`AstroUnit` giving the value's unit.
+    kind_id : int
+        Foreign key to the :class:`ParameterKind` (the named quantity).
     target : Target
         The target this parameter describes.
-    unit : AstroUnit
-        The unit the value is expressed in.
+    kind : ParameterKind
+        The named quantity this parameter measures (carries the unit).
 
     Notes
     -----
@@ -574,24 +574,24 @@ class AstroParameter(LCDBModel):
     responsibility: the model stores and returns both verbatim and performs
     no unit conversion or scale normalization.
 
-    The unique constraint on ``(target_id, unit_id)`` permits one parameter
-    per unit on a given target. Because each :class:`AstroUnit` has a unique
-    ``name``, that is equivalently one parameter per name -- so ``name``
-    identifies a parameter within its target.
+    The unique constraint on ``(target_id, kind_id)`` permits one parameter
+    per kind on a given target. Because each :class:`ParameterKind` has a
+    unique ``name``, that is equivalently one parameter per name -- so
+    ``name`` identifies a parameter within its target.
     """
 
     __tablename__ = "astro_parameter"
     __table_args__ = (
         sa.UniqueConstraint(
             "target_id",
-            "unit_id",
+            "kind_id",
         ),
     )
 
     id: orm.Mapped[int] = orm.mapped_column(sa.BigInteger, primary_key=True)
-    # Read-only view of the parameter kind; mirrors unit.name. Assign the kind
-    # on the AstroUnit -- writing here would rename the shared unit.
-    name: ap.AssociationProxy[str] = ap.association_proxy("unit", "name")
+    # Read-only view of the parameter kind; mirrors kind.name. Assign the kind
+    # on the ParameterKind -- writing here would rename the shared kind.
+    name: ap.AssociationProxy[str] = ap.association_proxy("kind", "name")
     value: orm.Mapped[float]
     upper_error: orm.Mapped[float]
     lower_error: orm.Mapped[float]
@@ -599,8 +599,8 @@ class AstroParameter(LCDBModel):
         sa.ForeignKey(Target.id, ondelete="CASCADE", onupdate="CASCADE"),
         index=True,
     )
-    unit_id: orm.Mapped[int] = orm.mapped_column(
-        sa.ForeignKey(AstroUnit.id, ondelete="RESTRICT"),
+    kind_id: orm.Mapped[int] = orm.mapped_column(
+        sa.ForeignKey(ParameterKind.id, ondelete="RESTRICT"),
         index=True,
     )
 
@@ -608,7 +608,7 @@ class AstroParameter(LCDBModel):
     target: orm.Mapped["Target"] = orm.relationship(
         back_populates="parameters",
     )
-    unit: orm.Mapped["AstroUnit"] = orm.relationship(
+    kind: orm.Mapped["ParameterKind"] = orm.relationship(
         back_populates="parameters",
     )
 
@@ -619,21 +619,21 @@ class AstroParameter(LCDBModel):
         Returns
         -------
         astropy.units.Quantity
-            ``self.value * self.unit.as_unit()``, using ``value`` verbatim
+            ``self.value * self.kind.as_unit()``, using ``value`` verbatim
             with no scale conversion.
 
         Notes
         -----
-        Requires the :attr:`unit` relationship; an attached instance
-        lazy-loads it. Raises ``AttributeError`` if :attr:`unit` is ``None``.
+        Requires the :attr:`kind` relationship; an attached instance
+        lazy-loads it. Raises ``AttributeError`` if :attr:`kind` is ``None``.
         """
-        return self.value * self.unit.as_unit()
+        return self.value * self.kind.as_unit()
 
     def __repr__(self) -> str:
         return (
             f"<AstroParameter(id={self.id!r}, name={self.name!r}, "
             f"value={self.value!r}, target={self.target_id!r}, "
-            f"unit={self.unit_id!r})>"
+            f"kind={self.kind_id!r})>"
         )
 
     def __rich_repr__(self):
@@ -641,4 +641,4 @@ class AstroParameter(LCDBModel):
         yield "name", self.name
         yield "value", self.value
         yield "target", self.target_id
-        yield "unit", self.unit_id
+        yield "kind", self.kind_id

--- a/src/lightcurvedb/models/target.py
+++ b/src/lightcurvedb/models/target.py
@@ -351,6 +351,44 @@ class Alias(LCDBModel):
 
 
 class AstroUnit(LCDBModel):
+    """
+    A physical unit, stored as its astropy string representation.
+
+    AstroUnit persists an :class:`astropy.units.UnitBase` by its generic
+    string form (``unit_str``) and rebuilds the live unit on demand via
+    :meth:`as_unit`. Storing the string keeps arbitrary named and composite
+    units (``m``, ``mag``, ``erg / (cm2 s)``) representable without a fixed
+    enumeration, while round-tripping exactly for the physically meaningful
+    units used in practice.
+
+    Attributes
+    ----------
+    id : int
+        Primary key identifier.
+    name : str
+        Human-readable label for the unit (e.g., "effective temperature").
+    unit_str : str
+        The unit's astropy generic string form, e.g. ``"K"`` or ``"m / s"``.
+    description : str
+        Optional free-text description; defaults to an empty string.
+
+    Notes
+    -----
+    The reconstructed unit follows :class:`astropy.units.UnitBase` equality,
+    which compares physical decomposition and scale. Extreme-magnitude
+    composites can exceed float64 range during astropy's own decomposition;
+    such units fall outside the intended scope.
+
+    Examples
+    --------
+    >>> from astropy import units as u
+    >>> unit = AstroUnit.reflect_astropy_unit(u.m / u.s, name="velocity")
+    >>> unit.unit_str
+    'm / s'
+    >>> unit.as_unit() == u.m / u.s
+    True
+    """
+
     __tablename__ = "astro_unit"
     id: orm.Mapped[int] = orm.mapped_column(primary_key=True)
     name: orm.Mapped[str]
@@ -358,15 +396,59 @@ class AstroUnit(LCDBModel):
     description: orm.Mapped[str] = orm.mapped_column(sa.TEXT, default="")
 
     def as_unit(self):
+        """
+        Reconstruct the live astropy unit from ``unit_str``.
+
+        Returns
+        -------
+        astropy.units.UnitBase
+            The unit parsed from :attr:`unit_str` via
+            :func:`astropy.units.Unit`.
+        """
         return u.Unit(self.unit_str)
 
     @classmethod
     def reflect_astropy_unit(
         cls, astropy_unit_or_quantity: u.UnitBase | u.Quantity, **kwargs
     ) -> "AstroUnit":
-        # Match on UnitBase, not u.Unit: irreducible units (u.m) and composite
-        # units (u.m / u.s) are UnitBase subclasses but NOT u.Unit instances,
-        # so ``case u.Unit()`` would reject everything except prefixed units.
+        """
+        Build an :class:`AstroUnit` from an astropy unit or quantity.
+
+        The unit is serialized with ``str()``. For a quantity only its unit
+        is stored; the scalar magnitude is discarded.
+
+        Parameters
+        ----------
+        astropy_unit_or_quantity : UnitBase or Quantity
+            An :class:`astropy.units.UnitBase` to reflect, or an
+            :class:`astropy.units.Quantity` whose unit is reflected.
+        **kwargs
+            Extra column values forwarded to the constructor, e.g. ``name``
+            (required; ``NOT NULL``) and ``description``.
+
+        Returns
+        -------
+        AstroUnit
+            An unsaved instance with ``unit_str`` set from the input.
+
+        Raises
+        ------
+        NotImplementedError
+            If the argument is neither a unit nor a quantity.
+
+        Notes
+        -----
+        Matching is on :class:`astropy.units.UnitBase`, not
+        :class:`astropy.units.Unit`: irreducible units (``u.m``) and composite
+        units (``u.m / u.s``) are ``UnitBase`` subclasses but not ``Unit``
+        instances, so matching ``Unit`` would reject all but prefixed units.
+
+        Examples
+        --------
+        >>> from astropy import units as u
+        >>> AstroUnit.reflect_astropy_unit(u.K, name="temp").unit_str
+        'K'
+        """
         match astropy_unit_or_quantity:
             case u.UnitBase():
                 return cls(unit_str=str(astropy_unit_or_quantity), **kwargs)
@@ -378,6 +460,39 @@ class AstroUnit(LCDBModel):
 
 
 class AstroParameter(LCDBModel):
+    """
+    A measured astrophysical quantity for a target, with asymmetric errors.
+
+    AstroParameter stores a scalar ``value`` alongside independent upper and
+    lower uncertainties and a reference to the :class:`AstroUnit` the value is
+    expressed in. The split errors capture the common ``value (+upper,
+    -lower)`` reporting convention used in the literature.
+
+    Attributes
+    ----------
+    id : int
+        Primary key identifier.
+    value : float
+        The parameter value, expressed in the linked unit.
+    upper_error : float
+        Upper (positive-direction) uncertainty on ``value``.
+    lower_error : float
+        Lower (negative-direction) uncertainty on ``value``.
+    target_id : int
+        Foreign key to the :class:`Target` this parameter describes.
+    unit_id : int
+        Foreign key to the :class:`AstroUnit` giving the value's unit.
+
+    Notes
+    -----
+    Keeping ``value`` consistent with its unit is the caller's
+    responsibility: the model stores and returns both verbatim and performs
+    no unit conversion or scale normalization.
+
+    The unique constraint on ``(target_id, unit_id)`` permits at most one
+    parameter per unit on a given target.
+    """
+
     __tablename__ = "astro_parameter"
     __table_args__ = (
         sa.UniqueConstraint(

--- a/src/lightcurvedb/models/target.py
+++ b/src/lightcurvedb/models/target.py
@@ -225,16 +225,16 @@ class Target(LCDBModel):
     datasets: orm.Mapped[list["DataSet"]] = orm.relationship(
         back_populates="target"
     )
-    target_specific_times: orm.Mapped[
-        list["TargetSpecificTime"]
-    ] = orm.relationship(
-        back_populates="target",
-        cascade="all, delete-orphan",
-        passive_deletes=True,
+    target_specific_times: orm.Mapped[list["TargetSpecificTime"]] = (
+        orm.relationship(
+            back_populates="target",
+            cascade="all, delete-orphan",
+            passive_deletes=True,
+        )
     )
-    quality_flag_arrays: orm.Mapped[
-        list["QualityFlagArray"]
-    ] = orm.relationship(back_populates="target")
+    quality_flag_arrays: orm.Mapped[list["QualityFlagArray"]] = (
+        orm.relationship(back_populates="target")
+    )
 
     def __repr__(self) -> str:
         return (
@@ -348,3 +348,51 @@ class Alias(LCDBModel):
         yield "id", self.id
         yield "target", self.target_id
         yield "counterpart", self.counterpart_id
+
+
+class AstroUnit(LCDBModel):
+    __tablename__ = "astro_unit"
+    id: orm.Mapped[int] = orm.mapped_column(primary_key=True)
+    name: orm.Mapped[str]
+    unit_str: orm.Mapped[str]
+    description: orm.Mapped[str] = orm.mapped_column(sa.TEXT, default="")
+
+    def as_unit(self):
+        return u.Unit(self.unit_str)
+
+    @classmethod
+    def reflect_astropy_unit(
+        cls, astropy_unit_or_quantity: u.UnitBase | u.Quantity, **kwargs
+    ) -> "AstroUnit":
+        # Match on UnitBase, not u.Unit: irreducible units (u.m) and composite
+        # units (u.m / u.s) are UnitBase subclasses but NOT u.Unit instances,
+        # so ``case u.Unit()`` would reject everything except prefixed units.
+        match astropy_unit_or_quantity:
+            case u.UnitBase():
+                return cls(unit_str=str(astropy_unit_or_quantity), **kwargs)
+            case u.Quantity():
+                unit = astropy_unit_or_quantity.unit
+                return cls(unit_str=str(unit), **kwargs)
+            case _:
+                raise NotImplementedError
+
+
+class AstroParameter(LCDBModel):
+    __tablename__ = "astro_parameter"
+    __table_args__ = (
+        sa.UniqueConstraint(
+            "target_id",
+            "unit_id",
+        ),
+    )
+
+    id: orm.Mapped[int] = orm.mapped_column(sa.BigInteger, primary_key=True)
+    value: orm.Mapped[float]
+    upper_error: orm.Mapped[float]
+    lower_error: orm.Mapped[float]
+    target_id: orm.Mapped[int] = orm.mapped_column(
+        sa.ForeignKey(Target.id), index=True
+    )
+    unit_id: orm.Mapped[int] = orm.mapped_column(
+        sa.ForeignKey(AstroUnit.id), index=True
+    )

--- a/tests/strategies/astro.py
+++ b/tests/strategies/astro.py
@@ -1,9 +1,9 @@
-"""Hypothesis strategies for astropy units and :class:`AstroUnit` models.
+"""Hypothesis strategies for astropy units and :class:`ParameterKind` models.
 
 The strategies draw real units defined in :mod:`astropy.units` -- both named
 units (``m``, ``km``, ``mag`` ...) and composites built from them (``m / s``,
 ``kg m2`` ...) -- so tests can prove that the string serialization used by
-:class:`~lightcurvedb.models.AstroUnit` survives a round-trip through the
+:class:`~lightcurvedb.models.ParameterKind` survives a round-trip through the
 database.
 """
 
@@ -11,7 +11,7 @@ import astropy.units as u
 from astropy.units import UnitBase
 from hypothesis import strategies as st
 
-from lightcurvedb.models import AstroUnit
+from lightcurvedb.models import ParameterKind
 
 
 def is_roundtrippable(unit: UnitBase) -> bool:
@@ -68,7 +68,7 @@ def astropy_composite_units(max_leaves: int = 5):
     float64 ceiling (e.g. ``foe**6`` ~ 1e306), where astropy's own
     decomposition overflows or loses precision and the round-trip ``==`` stops
     holding. ``is_roundtrippable`` drops exactly those; that is an astropy
-    numeric limit, not an ``AstroUnit`` defect, and out of scope for the
+    numeric limit, not an ``ParameterKind`` defect, and out of scope for the
     developer-maintained units this models.
     """
     base = astropy_named_units()
@@ -92,11 +92,11 @@ def astropy_composite_units(max_leaves: int = 5):
     return tree.filter(lambda x: len(x.bases) > 0 and is_roundtrippable(x))
 
 
-def astro_units(units=None, name=None):
-    """Draw :class:`AstroUnit` instances reflected from astropy units.
+def parameter_kinds(units=None, name=None):
+    """Draw :class:`ParameterKind` instances reflected from astropy units.
 
-    ``AstroUnit.name`` is NOT NULL and ``reflect_astropy_unit`` won't set it,
-    so ``name`` defaults to the serialized unit string.
+    ``ParameterKind.name`` is NOT NULL and ``reflect_astropy_unit`` won't set
+    it, so ``name`` defaults to the serialized unit string.
     """
     units = (
         units
@@ -104,7 +104,7 @@ def astro_units(units=None, name=None):
         else st.one_of(astropy_named_units(), astropy_composite_units())
     )
     return units.map(
-        lambda unit: AstroUnit.reflect_astropy_unit(
+        lambda unit: ParameterKind.reflect_astropy_unit(
             unit, name=name if name is not None else str(unit)
         )
     )

--- a/tests/strategies/astro.py
+++ b/tests/strategies/astro.py
@@ -1,0 +1,110 @@
+"""Hypothesis strategies for astropy units and :class:`AstroUnit` models.
+
+The strategies draw real units defined in :mod:`astropy.units` -- both named
+units (``m``, ``km``, ``mag`` ...) and composites built from them (``m / s``,
+``kg m2`` ...) -- so tests can prove that the string serialization used by
+:class:`~lightcurvedb.models.AstroUnit` survives a round-trip through the
+database.
+"""
+
+import astropy.units as u
+from astropy.units import UnitBase
+from hypothesis import strategies as st
+
+from lightcurvedb.models import AstroUnit
+
+
+def is_roundtrippable(unit: UnitBase) -> bool:
+    """Whether ``u.Unit(str(unit))`` reproduces ``unit``.
+
+    ``UnitBase.__eq__`` compares physical decomposition *and* scale, so this
+    rejects any unit whose string form loses dimension or scale. It is a safety
+    net rather than a heavy filter: on astropy 8.0.0 every named unit passes.
+    """
+    try:
+        return u.Unit(str(unit)) == unit
+    except Exception:
+        return False
+
+
+def _collect_named_units() -> list[UnitBase]:
+    """All round-trippable units exposed as attributes of :mod:`astropy.units`.
+
+    Deduped by serialized form so the ~4000 prefixed units (``km``, ``mm`` ...)
+    don't swamp ``sampled_from``'s shrinking toward the first element.
+    """
+    seen: dict[str, UnitBase] = {}
+    for name in dir(u):
+        if name.startswith("_"):
+            continue
+        obj = getattr(u, name, None)
+        if isinstance(obj, UnitBase) and is_roundtrippable(obj):
+            seen.setdefault(str(obj), obj)
+    return list(seen.values())
+
+
+_NAMED_UNITS = _collect_named_units()
+assert _NAMED_UNITS, "no astropy units collected; sampled_from([]) would raise"
+
+
+def astropy_named_units():
+    """Draw a single named astropy unit (round-trippable by construction)."""
+    return st.sampled_from(_NAMED_UNITS)
+
+
+def _safe_pow(args):
+    unit, exponent = args
+    return unit**exponent
+
+
+def astropy_composite_units(max_leaves: int = 5):
+    """Draw a composite unit from ``*``, ``/`` and integer powers.
+
+    Powers range over ``[-3, 3] \\ {0}``. Filtered to round-trippable units so
+    consumers can assert ``u.Unit(str(unit)) == unit`` directly.
+
+    The named pool includes extreme-magnitude units (``foe``, ``Bol``,
+    quetta/exa prefixes). Powered and multiplied, these reach scales near the
+    float64 ceiling (e.g. ``foe**6`` ~ 1e306), where astropy's own
+    decomposition overflows or loses precision and the round-trip ``==`` stops
+    holding. ``is_roundtrippable`` drops exactly those; that is an astropy
+    numeric limit, not an ``AstroUnit`` defect, and out of scope for the
+    developer-maintained units this models.
+    """
+    base = astropy_named_units()
+    # Exclude exponent 0: ``unit ** 0`` collapses to dimensionless. Bound the
+    # range so composite strings stay short and cheap to re-parse.
+    powers = st.integers(min_value=-3, max_value=3).filter(lambda e: e != 0)
+
+    def extend(children):
+        powered = st.tuples(children, powers).map(_safe_pow)
+        binop = st.tuples(children, children).flatmap(
+            lambda pair: st.sampled_from(
+                [pair[0] * pair[1], pair[0] / pair[1]]
+            )
+        )
+        return st.one_of(powered, binop)
+
+    tree = st.recursive(base, extend, max_leaves=max_leaves)
+    # Drop dimensionless via ``len(x.bases)`` not ``x != dimensionless``:
+    # comparing units decomposes to base SI and overflows float64 for extreme
+    # composites, raising during generation. ``.bases`` is a plain attribute.
+    return tree.filter(lambda x: len(x.bases) > 0 and is_roundtrippable(x))
+
+
+def astro_units(units=None, name=None):
+    """Draw :class:`AstroUnit` instances reflected from astropy units.
+
+    ``AstroUnit.name`` is NOT NULL and ``reflect_astropy_unit`` won't set it,
+    so ``name`` defaults to the serialized unit string.
+    """
+    units = (
+        units
+        if units is not None
+        else st.one_of(astropy_named_units(), astropy_composite_units())
+    )
+    return units.map(
+        lambda unit: AstroUnit.reflect_astropy_unit(
+            unit, name=name if name is not None else str(unit)
+        )
+    )

--- a/tests/test_astro_units.py
+++ b/tests/test_astro_units.py
@@ -1,6 +1,6 @@
-"""Tests that :class:`AstroUnit` serializes astropy units losslessly.
+"""Tests that :class:`ParameterKind` serializes astropy units losslessly.
 
-``AstroUnit`` stores a unit as ``str(unit)`` and rebuilds it with
+``ParameterKind`` stores a unit as ``str(unit)`` and rebuilds it with
 ``u.Unit(unit_str)``. These tests draw real astropy units (named and composite)
 and assert the round-trip is exact -- in memory and through the database.
 
@@ -17,9 +17,9 @@ from sqlalchemy import delete, exc, orm, select
 
 from lightcurvedb.models import (
     AstroParameter,
-    AstroUnit,
     Mission,
     MissionCatalog,
+    ParameterKind,
     Target,
 )
 
@@ -55,41 +55,41 @@ def _make_target(
     return target
 
 
-def _make_unit(session: orm.Session, astropy_unit, name: str) -> AstroUnit:
-    """Persist and return an AstroUnit reflected from an astropy unit."""
-    unit = AstroUnit.reflect_astropy_unit(astropy_unit, name=name)
-    session.add(unit)
+def _make_kind(session: orm.Session, astropy_unit, name: str) -> ParameterKind:
+    """Persist and return a ParameterKind reflected from an astropy unit."""
+    kind = ParameterKind.reflect_astropy_unit(astropy_unit, name=name)
+    session.add(kind)
     session.flush()
-    return unit
+    return kind
 
 
-class TestAstroUnit:
+class TestParameterKind:
     # --- pure reflection: no DB, no Hypothesis ------------------------------
     def test_reflect_from_unit(self):
-        au = AstroUnit.reflect_astropy_unit(u.m, name="meter")
+        au = ParameterKind.reflect_astropy_unit(u.m, name="meter")
         assert au.unit_str == "m"
         assert au.as_unit() == u.m
 
     def test_reflect_from_composite_unit(self):
-        au = AstroUnit.reflect_astropy_unit(u.m / u.s, name="velocity")
+        au = ParameterKind.reflect_astropy_unit(u.m / u.s, name="velocity")
         assert au.as_unit() == u.m / u.s
 
     def test_reflect_from_quantity_uses_unit(self):
         # The scalar magnitude is intentionally dropped; only the unit is kept.
-        au = AstroUnit.reflect_astropy_unit(3.0 * u.m, name="meter")
+        au = ParameterKind.reflect_astropy_unit(3.0 * u.m, name="meter")
         assert au.unit_str == "m"
         assert au.as_unit() == u.m
 
     @pytest.mark.parametrize("bad", [1.0, "m", None, object()])
     def test_reflect_rejects_non_unit(self, bad):
         with pytest.raises(NotImplementedError):
-            AstroUnit.reflect_astropy_unit(bad, name="x")
+            ParameterKind.reflect_astropy_unit(bad, name="x")
 
     # --- no-DB property: str <-> Unit round-trip ----------------------------
     @given(unit=astro_st.astropy_named_units())
     def test_named_unit_str_roundtrip(self, unit):
         assert u.Unit(str(unit)) == unit
-        au = AstroUnit.reflect_astropy_unit(unit, name=str(unit))
+        au = ParameterKind.reflect_astropy_unit(unit, name=str(unit))
         assert au.as_unit() == unit
 
     @given(unit=astro_st.astropy_composite_units())
@@ -109,14 +109,14 @@ class TestAstroUnit:
         deadline=None,  # each example does a real commit
     )
     def test_db_roundtrip(self, v2_db: orm.Session, unit):
-        au = AstroUnit.reflect_astropy_unit(unit, name=str(unit))
+        au = ParameterKind.reflect_astropy_unit(unit, name=str(unit))
         v2_db.add(au)
         v2_db.commit()
         v2_db.refresh(au)
         assert au.id is not None
 
         fetched = v2_db.execute(
-            select(AstroUnit).where(AstroUnit.id == au.id)
+            select(ParameterKind).where(ParameterKind.id == au.id)
         ).scalar_one()
         assert fetched.unit_str == str(unit)
         assert fetched.as_unit() == unit
@@ -133,8 +133,8 @@ class TestAstroParameter:
     Scale/unit *correctness* is a developer contract: the layer stores
     ``value`` together with its unit and returns both verbatim, performing no
     conversion or normalization. A parameter's ``name`` is read-only, mirrored
-    from its unit's name, so the kind is set on the :class:`AstroUnit`; with
-    ``unique(target_id, unit_id)`` a target holds one parameter per kind,
+    from its kind's name, so the kind is set on the :class:`ParameterKind`;
+    with ``unique(target_id, kind_id)`` a target holds one parameter per kind,
     reachable by keyword through ``target.parameters_by_name`` (or
     ``target[name]``).
     """
@@ -142,11 +142,11 @@ class TestAstroParameter:
     def test_quantity_roundtrip_value_and_unit(self, v2_db: orm.Session):
         catalog = _make_catalog(v2_db, "PARAM_QTY")
         target = _make_target(v2_db, catalog, 1001)
-        # The unit carries the parameter kind as its (unique) name.
-        unit = _make_unit(v2_db, u.K, "effective_temperature")
+        # The kind carries the parameter name and its unit.
+        kind = _make_kind(v2_db, u.K, "effective_temperature")
         param = AstroParameter(
             target=target,
-            unit=unit,
+            kind=kind,
             value=5772.0,
             upper_error=50.0,
             lower_error=40.0,
@@ -158,17 +158,17 @@ class TestAstroParameter:
             select(AstroParameter).where(AstroParameter.id == param.id)
         ).scalar_one()
         assert fetched.value == 5772.0
-        assert fetched.name == "effective_temperature"  # mirrored unit.name
-        assert fetched.unit.as_unit() == u.K
+        assert fetched.name == "effective_temperature"  # mirrored kind.name
+        assert fetched.kind.as_unit() == u.K
         assert fetched.as_quantity() == 5772.0 * u.K
 
     def test_asymmetric_errors_preserved(self, v2_db: orm.Session):
         catalog = _make_catalog(v2_db, "PARAM_ERR")
         target = _make_target(v2_db, catalog, 2001)
-        unit = _make_unit(v2_db, u.day, "period")
+        kind = _make_kind(v2_db, u.day, "period")
         param = AstroParameter(
             target=target,
-            unit=unit,
+            kind=kind,
             value=3.5,
             upper_error=0.2,
             lower_error=0.1,
@@ -187,10 +187,10 @@ class TestAstroParameter:
         catalog = _make_catalog(v2_db, "PARAM_VERBATIM")
         target = _make_target(v2_db, catalog, 3001)
         # km deliberately NOT normalized to m: the layer stores it as-is.
-        unit = _make_unit(v2_db, u.km, "distance")
+        kind = _make_kind(v2_db, u.km, "distance")
         param = AstroParameter(
             target=target,
-            unit=unit,
+            kind=kind,
             value=149.6e6,
             upper_error=0.1e6,
             lower_error=0.1e6,
@@ -202,26 +202,26 @@ class TestAstroParameter:
             select(AstroParameter).where(AstroParameter.id == param.id)
         ).scalar_one()
         assert fetched.value == 149.6e6  # not 1.496e11
-        assert fetched.unit.unit_str == "km"
+        assert fetched.kind.unit_str == "km"
         assert fetched.as_quantity() == 149.6e6 * u.km
 
     def test_target_parameters_navigation(self, v2_db: orm.Session):
         catalog = _make_catalog(v2_db, "NAV_PARAMS")
         target = _make_target(v2_db, catalog, 4001)
-        temp = _make_unit(v2_db, u.K, "effective_temperature")
-        period = _make_unit(v2_db, u.day, "period")
+        temp = _make_kind(v2_db, u.K, "effective_temperature")
+        period = _make_kind(v2_db, u.day, "period")
         v2_db.add_all(
             [
                 AstroParameter(
                     target=target,
-                    unit=temp,
+                    kind=temp,
                     value=5772.0,
                     upper_error=1.0,
                     lower_error=1.0,
                 ),
                 AstroParameter(
                     target=target,
-                    unit=period,
+                    kind=period,
                     value=3.5,
                     upper_error=0.1,
                     lower_error=0.1,
@@ -232,27 +232,27 @@ class TestAstroParameter:
         v2_db.refresh(target)
 
         assert len(target.parameters) == 2
-        units = [p.unit.as_unit() for p in target.parameters]
-        assert u.K in units
-        assert u.day in units
+        kind_units = [p.kind.as_unit() for p in target.parameters]
+        assert u.K in kind_units
+        assert u.day in kind_units
 
     def test_parameters_by_name_keyed_access(self, v2_db: orm.Session):
         catalog = _make_catalog(v2_db, "BY_NAME")
         target = _make_target(v2_db, catalog, 8001)
-        temp = _make_unit(v2_db, u.K, "effective_temperature")
-        radius = _make_unit(v2_db, u.solRad, "radius")
+        temp = _make_kind(v2_db, u.K, "effective_temperature")
+        radius = _make_kind(v2_db, u.solRad, "radius")
         v2_db.add_all(
             [
                 AstroParameter(
                     target=target,
-                    unit=temp,
+                    kind=temp,
                     value=5772.0,
                     upper_error=50.0,
                     lower_error=40.0,
                 ),
                 AstroParameter(
                     target=target,
-                    unit=radius,
+                    kind=radius,
                     value=1.0,
                     upper_error=0.1,
                     lower_error=0.1,
@@ -266,16 +266,16 @@ class TestAstroParameter:
         assert set(by_name) == {"effective_temperature", "radius"}
         assert by_name["effective_temperature"].value == 5772.0
         assert by_name["effective_temperature"].as_quantity() == 5772.0 * u.K
-        assert by_name["radius"].unit.as_unit() == u.solRad
+        assert by_name["radius"].kind.as_unit() == u.solRad
 
     def test_getitem_returns_quantity_by_name(self, v2_db: orm.Session):
         catalog = _make_catalog(v2_db, "GETITEM")
         target = _make_target(v2_db, catalog, 11001)
-        temp = _make_unit(v2_db, u.K, "effective_temperature")
+        temp = _make_kind(v2_db, u.K, "effective_temperature")
         v2_db.add(
             AstroParameter(
                 target=target,
-                unit=temp,
+                kind=temp,
                 value=5772.0,
                 upper_error=50.0,
                 lower_error=40.0,
@@ -291,21 +291,21 @@ class TestAstroParameter:
     def test_duplicate_kind_rejected(self, v2_db: orm.Session):
         catalog = _make_catalog(v2_db, "DUP_KIND")
         target = _make_target(v2_db, catalog, 10001)
-        temp = _make_unit(v2_db, u.K, "effective_temperature")
-        # A target holds at most one parameter per unit/kind
-        # (unique(target_id, unit_id)).
+        temp = _make_kind(v2_db, u.K, "effective_temperature")
+        # A target holds at most one parameter per kind
+        # (unique(target_id, kind_id)).
         v2_db.add_all(
             [
                 AstroParameter(
                     target=target,
-                    unit=temp,
+                    kind=temp,
                     value=5772.0,
                     upper_error=1.0,
                     lower_error=1.0,
                 ),
                 AstroParameter(
                     target=target,
-                    unit=temp,
+                    kind=temp,
                     value=6000.0,
                     upper_error=1.0,
                     lower_error=1.0,
@@ -316,23 +316,23 @@ class TestAstroParameter:
             v2_db.commit()
         v2_db.rollback()
 
-    def test_unit_parameters_back_reference(self, v2_db: orm.Session):
+    def test_kind_parameters_back_reference(self, v2_db: orm.Session):
         catalog = _make_catalog(v2_db, "BACKREF")
         t1 = _make_target(v2_db, catalog, 5001)
         t2 = _make_target(v2_db, catalog, 5002)
-        shared = _make_unit(v2_db, u.K, "effective_temperature")
+        shared = _make_kind(v2_db, u.K, "effective_temperature")
         v2_db.add_all(
             [
                 AstroParameter(
                     target=t1,
-                    unit=shared,
+                    kind=shared,
                     value=5772.0,
                     upper_error=1.0,
                     lower_error=1.0,
                 ),
                 AstroParameter(
                     target=t2,
-                    unit=shared,
+                    kind=shared,
                     value=4000.0,
                     upper_error=1.0,
                     lower_error=1.0,
@@ -348,11 +348,11 @@ class TestAstroParameter:
     def test_cascade_on_target_delete(self, v2_db: orm.Session):
         catalog = _make_catalog(v2_db, "CASCADE")
         target = _make_target(v2_db, catalog, 6001)
-        unit = _make_unit(v2_db, u.K, "effective_temperature")
+        kind = _make_kind(v2_db, u.K, "effective_temperature")
         v2_db.add(
             AstroParameter(
                 target=target,
-                unit=unit,
+                kind=kind,
                 value=5772.0,
                 upper_error=1.0,
                 lower_error=1.0,
@@ -365,17 +365,17 @@ class TestAstroParameter:
         v2_db.commit()
 
         assert v2_db.execute(select(AstroParameter)).scalars().all() == []
-        # The shared unit is a lookup; it must survive the target delete.
-        assert v2_db.get(AstroUnit, unit.id) is not None
+        # The shared kind is a lookup; it must survive the target delete.
+        assert v2_db.get(ParameterKind, kind.id) is not None
 
-    def test_restrict_on_unit_delete(self, v2_db: orm.Session):
+    def test_restrict_on_kind_delete(self, v2_db: orm.Session):
         catalog = _make_catalog(v2_db, "RESTRICT")
         target = _make_target(v2_db, catalog, 7001)
-        unit = _make_unit(v2_db, u.K, "effective_temperature")
+        kind = _make_kind(v2_db, u.K, "effective_temperature")
         v2_db.add(
             AstroParameter(
                 target=target,
-                unit=unit,
+                kind=kind,
                 value=5772.0,
                 upper_error=1.0,
                 lower_error=1.0,
@@ -383,8 +383,10 @@ class TestAstroParameter:
         )
         v2_db.commit()
 
-        # Deleting a unit still referenced by a parameter is blocked.
+        # Deleting a kind still referenced by a parameter is blocked.
         with pytest.raises(exc.IntegrityError):
-            v2_db.execute(delete(AstroUnit).where(AstroUnit.id == unit.id))
+            v2_db.execute(
+                delete(ParameterKind).where(ParameterKind.id == kind.id)
+            )
             v2_db.commit()
         v2_db.rollback()

--- a/tests/test_astro_units.py
+++ b/tests/test_astro_units.py
@@ -13,11 +13,54 @@ therefore the wrong assertion here).
 import astropy.units as u
 import pytest
 from hypothesis import HealthCheck, given, settings
-from sqlalchemy import orm, select
+from sqlalchemy import delete, exc, orm, select
 
-from lightcurvedb.models import AstroUnit
+from lightcurvedb.models import (
+    AstroParameter,
+    AstroUnit,
+    Mission,
+    MissionCatalog,
+    Target,
+)
 
 from .strategies import astro as astro_st
+
+
+def _make_catalog(session: orm.Session, mission_name: str) -> MissionCatalog:
+    """Persist a mission + catalog and return the catalog."""
+    mission = Mission(
+        name=mission_name,
+        description="astro-parameter test mission",
+        time_unit="day",
+        time_epoch=0.0,
+        time_epoch_scale="tdb",
+        time_epoch_format="jd",
+        time_format_name=mission_name,
+    )
+    catalog = MissionCatalog(
+        host_mission=mission, name="CAT", description="astro-param catalog"
+    )
+    session.add_all([mission, catalog])
+    session.flush()
+    return catalog
+
+
+def _make_target(
+    session: orm.Session, catalog: MissionCatalog, name: int
+) -> Target:
+    """Persist and return a target in the given catalog."""
+    target = Target(catalog=catalog, name=name)
+    session.add(target)
+    session.flush()
+    return target
+
+
+def _make_unit(session: orm.Session, astropy_unit, name: str) -> AstroUnit:
+    """Persist and return an AstroUnit reflected from an astropy unit."""
+    unit = AstroUnit.reflect_astropy_unit(astropy_unit, name=name)
+    session.add(unit)
+    session.flush()
+    return unit
 
 
 class TestAstroUnit:
@@ -85,42 +128,185 @@ class TestAstroUnit:
 
 
 class TestAstroParameter:
-    """Scaffold for the next round.
+    """Persistence and relationships for AstroParameter.
 
-    Design decision (resolved): scale/unit *correctness* is a developer
-    contract. The persistence layer does NOT convert or normalize -- it stores
-    ``value`` together with the associated unit and returns them unchanged.
-    Whatever scale a developer puts in is what they get back; keeping ``value``
-    consistent with its ``AstroUnit`` is on them. So the tests below assert
-    faithful round-trip, never normalization.
+    Scale/unit *correctness* is a developer contract: the layer stores
+    ``value`` together with its unit and returns both verbatim, performing no
+    conversion or normalization. Single-parameter round-trips and the
+    ``target`` / ``unit`` relationships are covered here.
 
-    Still open (blocks meaningful tests): how a parameter is identified. There
-    is no name/type field, yet ``unique(target_id, unit_id)`` forbids two
-    same-unit parameters on one target (e.g. a period and a timescale both in
-    ``day``). Likely needs a ``name``/``parameter_type`` column, making the
-    constraint ``(target_id, name)`` or ``(target_id, name, unit_id)``.
+    Still open: how a parameter is identified. There is no name/type field,
+    and ``unique(target_id, unit_id)`` forbids two same-unit parameters on one
+    target (e.g. a period and a timescale both in ``day``), so storing
+    multiple same-unit parameters on a target remains future work.
     """
 
-    @pytest.mark.skip(
-        reason="AstroParameter identity field undecided -- see class docstring"
-    )
     def test_quantity_roundtrip_value_and_unit(self, v2_db: orm.Session):
-        # Persist a parameter (value + AstroUnit); read it back and assert
-        # fetched.value * fetched.unit.as_unit() == the stored value*unit,
-        # exactly -- faithful persistence, no scale normalization.
-        raise NotImplementedError
+        catalog = _make_catalog(v2_db, "PARAM_QTY")
+        target = _make_target(v2_db, catalog, 1001)
+        unit = _make_unit(v2_db, u.K, "effective temperature")
+        param = AstroParameter(
+            target=target,
+            unit=unit,
+            value=5772.0,
+            upper_error=50.0,
+            lower_error=40.0,
+        )
+        v2_db.add(param)
+        v2_db.commit()
 
-    @pytest.mark.skip(
-        reason="AstroParameter identity field undecided -- see class docstring"
-    )
+        fetched = v2_db.execute(
+            select(AstroParameter).where(AstroParameter.id == param.id)
+        ).scalar_one()
+        assert fetched.value == 5772.0
+        assert fetched.unit.as_unit() == u.K
+        assert fetched.as_quantity() == 5772.0 * u.K
+
     def test_asymmetric_errors_preserved(self, v2_db: orm.Session):
-        # upper_error and lower_error survive independently (value -lo +hi).
-        raise NotImplementedError
+        catalog = _make_catalog(v2_db, "PARAM_ERR")
+        target = _make_target(v2_db, catalog, 2001)
+        unit = _make_unit(v2_db, u.day, "period")
+        param = AstroParameter(
+            target=target,
+            unit=unit,
+            value=3.5,
+            upper_error=0.2,
+            lower_error=0.1,
+        )
+        v2_db.add(param)
+        v2_db.commit()
 
-    @pytest.mark.skip(
-        reason="AstroParameter identity field undecided -- see class docstring"
-    )
+        fetched = v2_db.execute(
+            select(AstroParameter).where(AstroParameter.id == param.id)
+        ).scalar_one()
+        # The two errors survive independently (not collapsed or swapped).
+        assert fetched.upper_error == 0.2
+        assert fetched.lower_error == 0.1
+
     def test_value_and_unit_stored_verbatim(self, v2_db: orm.Session):
-        # Developer-contract scale: a value paired with a scaled/log unit is
-        # returned exactly as written; the layer performs no conversion.
-        raise NotImplementedError
+        catalog = _make_catalog(v2_db, "PARAM_VERBATIM")
+        target = _make_target(v2_db, catalog, 3001)
+        # km deliberately NOT normalized to m: the layer stores it as-is.
+        unit = _make_unit(v2_db, u.km, "distance")
+        param = AstroParameter(
+            target=target,
+            unit=unit,
+            value=149.6e6,
+            upper_error=0.1e6,
+            lower_error=0.1e6,
+        )
+        v2_db.add(param)
+        v2_db.commit()
+
+        fetched = v2_db.execute(
+            select(AstroParameter).where(AstroParameter.id == param.id)
+        ).scalar_one()
+        assert fetched.value == 149.6e6  # not 1.496e11
+        assert fetched.unit.unit_str == "km"
+        assert fetched.as_quantity() == 149.6e6 * u.km
+
+    def test_target_astro_parameters_navigation(self, v2_db: orm.Session):
+        catalog = _make_catalog(v2_db, "NAV_PARAMS")
+        target = _make_target(v2_db, catalog, 4001)
+        # Two params on one target need DIFFERENT units
+        # (unique(target_id, unit_id)).
+        temp = _make_unit(v2_db, u.K, "temperature")
+        period = _make_unit(v2_db, u.day, "period")
+        v2_db.add_all(
+            [
+                AstroParameter(
+                    target=target,
+                    unit=temp,
+                    value=5772.0,
+                    upper_error=1.0,
+                    lower_error=1.0,
+                ),
+                AstroParameter(
+                    target=target,
+                    unit=period,
+                    value=3.5,
+                    upper_error=0.1,
+                    lower_error=0.1,
+                ),
+            ]
+        )
+        v2_db.commit()
+        v2_db.refresh(target)
+
+        assert len(target.astro_parameters) == 2
+        units = [p.unit.as_unit() for p in target.astro_parameters]
+        assert u.K in units
+        assert u.day in units
+
+    def test_unit_parameters_back_reference(self, v2_db: orm.Session):
+        catalog = _make_catalog(v2_db, "BACKREF")
+        t1 = _make_target(v2_db, catalog, 5001)
+        t2 = _make_target(v2_db, catalog, 5002)
+        shared = _make_unit(v2_db, u.K, "temperature")
+        v2_db.add_all(
+            [
+                AstroParameter(
+                    target=t1,
+                    unit=shared,
+                    value=5772.0,
+                    upper_error=1.0,
+                    lower_error=1.0,
+                ),
+                AstroParameter(
+                    target=t2,
+                    unit=shared,
+                    value=4000.0,
+                    upper_error=1.0,
+                    lower_error=1.0,
+                ),
+            ]
+        )
+        v2_db.commit()
+        v2_db.refresh(shared)
+
+        assert len(shared.parameters) == 2
+        assert {p.target_id for p in shared.parameters} == {t1.id, t2.id}
+
+    def test_cascade_on_target_delete(self, v2_db: orm.Session):
+        catalog = _make_catalog(v2_db, "CASCADE")
+        target = _make_target(v2_db, catalog, 6001)
+        unit = _make_unit(v2_db, u.K, "temperature")
+        v2_db.add(
+            AstroParameter(
+                target=target,
+                unit=unit,
+                value=5772.0,
+                upper_error=1.0,
+                lower_error=1.0,
+            )
+        )
+        v2_db.commit()
+
+        # SQL-level delete exercises the DB FK cascade, not ORM cascade.
+        v2_db.execute(delete(Target).where(Target.id == target.id))
+        v2_db.commit()
+
+        assert v2_db.execute(select(AstroParameter)).scalars().all() == []
+        # The shared unit is a lookup; it must survive the target delete.
+        assert v2_db.get(AstroUnit, unit.id) is not None
+
+    def test_restrict_on_unit_delete(self, v2_db: orm.Session):
+        catalog = _make_catalog(v2_db, "RESTRICT")
+        target = _make_target(v2_db, catalog, 7001)
+        unit = _make_unit(v2_db, u.K, "temperature")
+        v2_db.add(
+            AstroParameter(
+                target=target,
+                unit=unit,
+                value=5772.0,
+                upper_error=1.0,
+                lower_error=1.0,
+            )
+        )
+        v2_db.commit()
+
+        # Deleting a unit still referenced by a parameter is blocked.
+        with pytest.raises(exc.IntegrityError):
+            v2_db.execute(delete(AstroUnit).where(AstroUnit.id == unit.id))
+            v2_db.commit()
+        v2_db.rollback()

--- a/tests/test_astro_units.py
+++ b/tests/test_astro_units.py
@@ -128,23 +128,22 @@ class TestAstroUnit:
 
 
 class TestAstroParameter:
-    """Persistence and relationships for AstroParameter.
+    """Persistence, relationships, and name-keyed access for AstroParameter.
 
     Scale/unit *correctness* is a developer contract: the layer stores
     ``value`` together with its unit and returns both verbatim, performing no
-    conversion or normalization. Single-parameter round-trips and the
-    ``target`` / ``unit`` relationships are covered here.
-
-    Still open: how a parameter is identified. There is no name/type field,
-    and ``unique(target_id, unit_id)`` forbids two same-unit parameters on one
-    target (e.g. a period and a timescale both in ``day``), so storing
-    multiple same-unit parameters on a target remains future work.
+    conversion or normalization. A parameter's ``name`` is read-only, mirrored
+    from its unit's name, so the kind is set on the :class:`AstroUnit`; with
+    ``unique(target_id, unit_id)`` a target holds one parameter per kind,
+    reachable by keyword through ``target.parameters_by_name`` (or
+    ``target[name]``).
     """
 
     def test_quantity_roundtrip_value_and_unit(self, v2_db: orm.Session):
         catalog = _make_catalog(v2_db, "PARAM_QTY")
         target = _make_target(v2_db, catalog, 1001)
-        unit = _make_unit(v2_db, u.K, "effective temperature")
+        # The unit carries the parameter kind as its (unique) name.
+        unit = _make_unit(v2_db, u.K, "effective_temperature")
         param = AstroParameter(
             target=target,
             unit=unit,
@@ -159,6 +158,7 @@ class TestAstroParameter:
             select(AstroParameter).where(AstroParameter.id == param.id)
         ).scalar_one()
         assert fetched.value == 5772.0
+        assert fetched.name == "effective_temperature"  # mirrored unit.name
         assert fetched.unit.as_unit() == u.K
         assert fetched.as_quantity() == 5772.0 * u.K
 
@@ -205,12 +205,10 @@ class TestAstroParameter:
         assert fetched.unit.unit_str == "km"
         assert fetched.as_quantity() == 149.6e6 * u.km
 
-    def test_target_astro_parameters_navigation(self, v2_db: orm.Session):
+    def test_target_parameters_navigation(self, v2_db: orm.Session):
         catalog = _make_catalog(v2_db, "NAV_PARAMS")
         target = _make_target(v2_db, catalog, 4001)
-        # Two params on one target need DIFFERENT units
-        # (unique(target_id, unit_id)).
-        temp = _make_unit(v2_db, u.K, "temperature")
+        temp = _make_unit(v2_db, u.K, "effective_temperature")
         period = _make_unit(v2_db, u.day, "period")
         v2_db.add_all(
             [
@@ -233,16 +231,96 @@ class TestAstroParameter:
         v2_db.commit()
         v2_db.refresh(target)
 
-        assert len(target.astro_parameters) == 2
-        units = [p.unit.as_unit() for p in target.astro_parameters]
+        assert len(target.parameters) == 2
+        units = [p.unit.as_unit() for p in target.parameters]
         assert u.K in units
         assert u.day in units
+
+    def test_parameters_by_name_keyed_access(self, v2_db: orm.Session):
+        catalog = _make_catalog(v2_db, "BY_NAME")
+        target = _make_target(v2_db, catalog, 8001)
+        temp = _make_unit(v2_db, u.K, "effective_temperature")
+        radius = _make_unit(v2_db, u.solRad, "radius")
+        v2_db.add_all(
+            [
+                AstroParameter(
+                    target=target,
+                    unit=temp,
+                    value=5772.0,
+                    upper_error=50.0,
+                    lower_error=40.0,
+                ),
+                AstroParameter(
+                    target=target,
+                    unit=radius,
+                    value=1.0,
+                    upper_error=0.1,
+                    lower_error=0.1,
+                ),
+            ]
+        )
+        v2_db.commit()
+        v2_db.refresh(target)
+
+        by_name = target.parameters_by_name
+        assert set(by_name) == {"effective_temperature", "radius"}
+        assert by_name["effective_temperature"].value == 5772.0
+        assert by_name["effective_temperature"].as_quantity() == 5772.0 * u.K
+        assert by_name["radius"].unit.as_unit() == u.solRad
+
+    def test_getitem_returns_quantity_by_name(self, v2_db: orm.Session):
+        catalog = _make_catalog(v2_db, "GETITEM")
+        target = _make_target(v2_db, catalog, 11001)
+        temp = _make_unit(v2_db, u.K, "effective_temperature")
+        v2_db.add(
+            AstroParameter(
+                target=target,
+                unit=temp,
+                value=5772.0,
+                upper_error=50.0,
+                lower_error=40.0,
+            )
+        )
+        v2_db.commit()
+        v2_db.refresh(target)
+
+        assert target["effective_temperature"] == 5772.0 * u.K
+        with pytest.raises(KeyError):
+            target["radius"]
+
+    def test_duplicate_kind_rejected(self, v2_db: orm.Session):
+        catalog = _make_catalog(v2_db, "DUP_KIND")
+        target = _make_target(v2_db, catalog, 10001)
+        temp = _make_unit(v2_db, u.K, "effective_temperature")
+        # A target holds at most one parameter per unit/kind
+        # (unique(target_id, unit_id)).
+        v2_db.add_all(
+            [
+                AstroParameter(
+                    target=target,
+                    unit=temp,
+                    value=5772.0,
+                    upper_error=1.0,
+                    lower_error=1.0,
+                ),
+                AstroParameter(
+                    target=target,
+                    unit=temp,
+                    value=6000.0,
+                    upper_error=1.0,
+                    lower_error=1.0,
+                ),
+            ]
+        )
+        with pytest.raises(exc.IntegrityError):
+            v2_db.commit()
+        v2_db.rollback()
 
     def test_unit_parameters_back_reference(self, v2_db: orm.Session):
         catalog = _make_catalog(v2_db, "BACKREF")
         t1 = _make_target(v2_db, catalog, 5001)
         t2 = _make_target(v2_db, catalog, 5002)
-        shared = _make_unit(v2_db, u.K, "temperature")
+        shared = _make_unit(v2_db, u.K, "effective_temperature")
         v2_db.add_all(
             [
                 AstroParameter(
@@ -270,7 +348,7 @@ class TestAstroParameter:
     def test_cascade_on_target_delete(self, v2_db: orm.Session):
         catalog = _make_catalog(v2_db, "CASCADE")
         target = _make_target(v2_db, catalog, 6001)
-        unit = _make_unit(v2_db, u.K, "temperature")
+        unit = _make_unit(v2_db, u.K, "effective_temperature")
         v2_db.add(
             AstroParameter(
                 target=target,
@@ -293,7 +371,7 @@ class TestAstroParameter:
     def test_restrict_on_unit_delete(self, v2_db: orm.Session):
         catalog = _make_catalog(v2_db, "RESTRICT")
         target = _make_target(v2_db, catalog, 7001)
-        unit = _make_unit(v2_db, u.K, "temperature")
+        unit = _make_unit(v2_db, u.K, "effective_temperature")
         v2_db.add(
             AstroParameter(
                 target=target,

--- a/tests/test_astro_units.py
+++ b/tests/test_astro_units.py
@@ -1,0 +1,126 @@
+"""Tests that :class:`AstroUnit` serializes astropy units losslessly.
+
+``AstroUnit`` stores a unit as ``str(unit)`` and rebuilds it with
+``u.Unit(unit_str)``. These tests draw real astropy units (named and composite)
+and assert the round-trip is exact -- in memory and through the database.
+
+Equality uses ``UnitBase.__eq__``, which compares physical decomposition *and*
+scale, so a serialization that lost (say) a ``km`` -> ``m`` scale factor would
+fail rather than slip through (``is_equivalent`` would ignore that and is
+therefore the wrong assertion here).
+"""
+
+import astropy.units as u
+import pytest
+from hypothesis import HealthCheck, given, settings
+from sqlalchemy import orm, select
+
+from lightcurvedb.models import AstroUnit
+
+from .strategies import astro as astro_st
+
+
+class TestAstroUnit:
+    # --- pure reflection: no DB, no Hypothesis ------------------------------
+    def test_reflect_from_unit(self):
+        au = AstroUnit.reflect_astropy_unit(u.m, name="meter")
+        assert au.unit_str == "m"
+        assert au.as_unit() == u.m
+
+    def test_reflect_from_composite_unit(self):
+        au = AstroUnit.reflect_astropy_unit(u.m / u.s, name="velocity")
+        assert au.as_unit() == u.m / u.s
+
+    def test_reflect_from_quantity_uses_unit(self):
+        # The scalar magnitude is intentionally dropped; only the unit is kept.
+        au = AstroUnit.reflect_astropy_unit(3.0 * u.m, name="meter")
+        assert au.unit_str == "m"
+        assert au.as_unit() == u.m
+
+    @pytest.mark.parametrize("bad", [1.0, "m", None, object()])
+    def test_reflect_rejects_non_unit(self, bad):
+        with pytest.raises(NotImplementedError):
+            AstroUnit.reflect_astropy_unit(bad, name="x")
+
+    # --- no-DB property: str <-> Unit round-trip ----------------------------
+    @given(unit=astro_st.astropy_named_units())
+    def test_named_unit_str_roundtrip(self, unit):
+        assert u.Unit(str(unit)) == unit
+        au = AstroUnit.reflect_astropy_unit(unit, name=str(unit))
+        assert au.as_unit() == unit
+
+    @given(unit=astro_st.astropy_composite_units())
+    def test_composite_unit_str_roundtrip(self, unit):
+        # The strategy filters to round-trippable units (excluding extreme
+        # magnitudes where astropy's own == overflows/loses precision); this
+        # asserts the contract holds for everything realistic it yields.
+        assert u.Unit(str(unit)) == unit
+
+    # --- DB round-trip: real Postgres session via v2_db ---------------------
+    @given(unit=astro_st.astropy_named_units())
+    @settings(
+        # v2_db is function-scoped but @given runs many examples inside one
+        # fixture setup; that sharing is deliberate here (see rollback below).
+        suppress_health_check=[HealthCheck.function_scoped_fixture],
+        max_examples=25,
+        deadline=None,  # each example does a real commit
+    )
+    def test_db_roundtrip(self, v2_db: orm.Session, unit):
+        au = AstroUnit.reflect_astropy_unit(unit, name=str(unit))
+        v2_db.add(au)
+        v2_db.commit()
+        v2_db.refresh(au)
+        assert au.id is not None
+
+        fetched = v2_db.execute(
+            select(AstroUnit).where(AstroUnit.id == au.id)
+        ).scalar_one()
+        assert fetched.unit_str == str(unit)
+        assert fetched.as_unit() == unit
+
+        # Clear the transaction so the next example starts fresh. Committed
+        # rows are harmless: unit_str has no unique constraint, so duplicate
+        # examples cannot collide.
+        v2_db.rollback()
+
+
+class TestAstroParameter:
+    """Scaffold for the next round.
+
+    Design decision (resolved): scale/unit *correctness* is a developer
+    contract. The persistence layer does NOT convert or normalize -- it stores
+    ``value`` together with the associated unit and returns them unchanged.
+    Whatever scale a developer puts in is what they get back; keeping ``value``
+    consistent with its ``AstroUnit`` is on them. So the tests below assert
+    faithful round-trip, never normalization.
+
+    Still open (blocks meaningful tests): how a parameter is identified. There
+    is no name/type field, yet ``unique(target_id, unit_id)`` forbids two
+    same-unit parameters on one target (e.g. a period and a timescale both in
+    ``day``). Likely needs a ``name``/``parameter_type`` column, making the
+    constraint ``(target_id, name)`` or ``(target_id, name, unit_id)``.
+    """
+
+    @pytest.mark.skip(
+        reason="AstroParameter identity field undecided -- see class docstring"
+    )
+    def test_quantity_roundtrip_value_and_unit(self, v2_db: orm.Session):
+        # Persist a parameter (value + AstroUnit); read it back and assert
+        # fetched.value * fetched.unit.as_unit() == the stored value*unit,
+        # exactly -- faithful persistence, no scale normalization.
+        raise NotImplementedError
+
+    @pytest.mark.skip(
+        reason="AstroParameter identity field undecided -- see class docstring"
+    )
+    def test_asymmetric_errors_preserved(self, v2_db: orm.Session):
+        # upper_error and lower_error survive independently (value -lo +hi).
+        raise NotImplementedError
+
+    @pytest.mark.skip(
+        reason="AstroParameter identity field undecided -- see class docstring"
+    )
+    def test_value_and_unit_stored_verbatim(self, v2_db: orm.Session):
+        # Developer-contract scale: a value paired with a scaled/log unit is
+        # returned exactly as written; the layer performs no conversion.
+        raise NotImplementedError


### PR DESCRIPTION
## Summary

Adds astrophysical parameters alongside `Target`, keyed by a descriptive name and stored unit-safely.

- **`ParameterKind`** (table `parameter_kind`) — a named quantity-kind: a unique `name` (the parameter keyword, e.g. `"effective_temperature"`) plus `unit_str` (its astropy unit, e.g. `"K"`). Round-trips an `astropy` unit through a string via `reflect_astropy_unit()` / `as_unit()` (compared with `UnitBase.__eq__`, i.e. decomposition **and** scale).
- **`AstroParameter`** — a measured `value` with asymmetric `upper_error`/`lower_error`, FK to `Target` and `ParameterKind`. `name` is a read-only association proxy to `kind.name`; `as_quantity()` returns `value * kind.as_unit()`.
- **`Target` quality-of-life access**:
  - `target.parameters` — writable list (Target owns its parameters; `cascade="all, delete-orphan"`).
  - `target.parameters_by_name` — viewonly keyed `dict[name, AstroParameter]` (`attribute_keyed_dict`).
  - `target["effective_temperature"]` — `__getitem__` returning the parameter as an astropy `Quantity`.

## Design notes

- **Storage**: the parameter name lives once per kind in the small `parameter_kind` lookup, not per row — at 1–10B targets × tens of params, a per-row `VARCHAR` name would cost ~hundreds of GB to several TB; this design keeps it ~flat.
- **Cascade semantics**: `Target` owns parameters (`ondelete=CASCADE`); `ParameterKind` is a shared lookup (`ondelete=RESTRICT`, can't be deleted while referenced). `unique(target_id, kind_id)` ⇒ one parameter per kind per target.
- No migrations: schema is created via `metadata.create_all`.

## Tests

- Property-based (`hypothesis`) astropy-unit round-trip over **named and composite** units, in memory and through PostgreSQL (`tests/strategies/astro.py`, `tests/test_astro_units.py`).
- `AstroParameter` persistence: value/asymmetric-error round-trip, `as_quantity`, verbatim (non-normalized) unit storage, `parameters` / `parameters_by_name` navigation, `target[name]`, duplicate-kind rejection, and DB-level cascade / RESTRICT delete behavior.
- Full suite green (258 passed); numpydoc docstrings throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
