### PR TITLE
feat(models): Target astrometry — coordinates, SkyCoord, proper motion

### DIFF
--- a/docs/source/schema.rst
+++ b/docs/source/schema.rst
@@ -84,12 +84,15 @@ Entity Relationship Diagram
            UUID host_mission_id FK
            string name UK
            string description
+           string coordinate_reference_frame
        }
 
        Target {
            bigint id PK
            int catalog_id FK
            bigint name
+           float right_ascension
+           float declination
        }
 
        Instrument {

--- a/src/lightcurvedb/models/target.py
+++ b/src/lightcurvedb/models/target.py
@@ -177,6 +177,11 @@ class Target(LCDBModel):
     declination : float, optional
         Declination in degrees, [-90, 90]. Interpreted in the catalog's
         ``coordinate_reference_frame``. Null unless a position is known.
+    pm_ra_cosdec : float, optional
+        Proper motion in right ascension, cos(dec)-corrected
+        (mu_alpha* = mu_alpha * cos(dec)), in mas/yr. Null unless known.
+    pm_dec : float, optional
+        Proper motion in declination, in mas/yr. Null unless known.
     catalog : MissionCatalog
         The catalog this target belongs to
     datasets : list[DataSet]
@@ -202,10 +207,16 @@ class Target(LCDBModel):
     when present to lie within valid celestial degrees -- RA in [0, 360) and
     Dec in [-90, 90]. The range bounds also reject NaN and +/-Infinity.
 
+    ``pm_ra_cosdec`` and ``pm_dec`` are likewise co-present (both null or both
+    set), must be finite when set (no NaN/+/-Infinity), and require a position
+    to be present (proper motion without ra/dec is rejected).
+
     :attr:`coordinate` is a hybrid attribute: on a loaded instance it returns
-    an :class:`astropy.coordinates.SkyCoord` (or ``None`` if the target has no
-    position); in a SQL expression it resolves to the
-    ``(right_ascension, declination)`` degree pair.
+    an :class:`astropy.coordinates.SkyCoord` (carrying proper-motion
+    differentials when ``pm_ra_cosdec`` / ``pm_dec`` are set, else
+    position-only), or ``None`` if the target has no position; in a SQL
+    expression it resolves to the ``(right_ascension, declination)`` degree
+    pair.
 
     Indexing a target by parameter name -- ``target["effective_temperature"]``
     -- returns that parameter as an astropy quantity (see
@@ -232,6 +243,26 @@ class Target(LCDBModel):
             " AND declination >= -90 AND declination <= 90)",
             name="ck_target_radec_range",
         ),
+        # Proper motion is co-present: both components set or both NULL.
+        sa.CheckConstraint(
+            "(pm_ra_cosdec IS NULL) = (pm_dec IS NULL)",
+            name="ck_target_pm_co_null",
+        ),
+        # Proper motion has no bounded range, so finiteness is enforced
+        # directly: reject NaN and +/-Infinity in either component.
+        sa.CheckConstraint(
+            "pm_ra_cosdec IS NULL OR ("
+            " pm_ra_cosdec <> 'NaN' AND pm_ra_cosdec <> 'Infinity'"
+            " AND pm_ra_cosdec <> '-Infinity'"
+            " AND pm_dec <> 'NaN' AND pm_dec <> 'Infinity'"
+            " AND pm_dec <> '-Infinity')",
+            name="ck_target_pm_finite",
+        ),
+        # Proper motion is meaningless without a position to anchor it.
+        sa.CheckConstraint(
+            "pm_ra_cosdec IS NULL OR right_ascension IS NOT NULL",
+            name="ck_target_pm_requires_position",
+        ),
     )
 
     id: orm.Mapped[int] = orm.mapped_column(sa.BigInteger, primary_key=True)
@@ -243,6 +274,11 @@ class Target(LCDBModel):
     name: orm.Mapped[int] = orm.mapped_column(sa.BigInteger)
     right_ascension: orm.Mapped[float | None]
     declination: orm.Mapped[float | None]
+    # Proper motion in mas/yr. pm_ra_cosdec is the cos(dec)-corrected RA rate
+    # (mu_alpha* = mu_alpha * cos(dec)), the Gaia/TIC convention and astropy's
+    # SkyCoord(pm_ra_cosdec=...) kwarg -- so it maps to a SkyCoord directly.
+    pm_ra_cosdec: orm.Mapped[float | None]
+    pm_dec: orm.Mapped[float | None]
 
     # Relationships
     catalog: orm.Mapped["MissionCatalog"] = orm.relationship(
@@ -320,10 +356,15 @@ class Target(LCDBModel):
         ``ck_target_radec_co_null`` constraint guarantees the two columns are
         set together, so a partial coordinate never occurs.
 
+        When :attr:`pm_ra_cosdec` / :attr:`pm_dec` are present the SkyCoord
+        also carries proper-motion differentials (in mas/yr); otherwise it is
+        position-only.
+
         Returns
         -------
         astropy.coordinates.SkyCoord or None
-            The position, or ``None`` if ra/dec are unset.
+            The position (with proper motion when available), or ``None`` if
+            ra/dec are unset.
 
         Notes
         -----
@@ -337,10 +378,17 @@ class Target(LCDBModel):
         """
         if self.right_ascension is None or self.declination is None:
             return None
+        proper_motion = {}
+        if self.pm_ra_cosdec is not None and self.pm_dec is not None:
+            proper_motion = {
+                "pm_ra_cosdec": self.pm_ra_cosdec * (u.mas / u.yr),
+                "pm_dec": self.pm_dec * (u.mas / u.yr),
+            }
         return SkyCoord(
             ra=self.right_ascension * u.deg,
             dec=self.declination * u.deg,
             frame=self.catalog.coordinate_reference_frame.lower(),
+            **proper_motion,
         )
 
     @coordinate.expression

--- a/src/lightcurvedb/models/target.py
+++ b/src/lightcurvedb/models/target.py
@@ -111,6 +111,10 @@ class MissionCatalog(LCDBModel, NameAndDescriptionMixin, CreatedOnMixin):
         Unique catalog name (e.g., "TIC" for TESS Input Catalog)
     description : str, optional
         Detailed description of the catalog
+    coordinate_reference_frame : str
+        Reference frame the catalog's target coordinates
+        (``Target.right_ascension`` / ``declination``) are expressed in.
+        Defaults to ``"J2000"``.
     host_mission : Mission
         Parent mission this catalog belongs to
     targets : list[Target]
@@ -124,6 +128,7 @@ class MissionCatalog(LCDBModel, NameAndDescriptionMixin, CreatedOnMixin):
     host_mission_id: orm.Mapped[uuid.UUID] = orm.mapped_column(
         sa.ForeignKey(Mission.id, ondelete="CASCADE")
     )
+    coordinate_reference_frame: orm.Mapped[str] = orm.mapped_column(default="J2000")
 
     # Relationships
     host_mission: orm.Mapped["Mission"] = orm.relationship(
@@ -161,6 +166,12 @@ class Target(LCDBModel):
         Foreign key to the MissionCatalog
     name : int
         Catalog-specific identifier (e.g., TIC ID)
+    right_ascension : float, optional
+        Right ascension in degrees, [0, 360). Interpreted in the catalog's
+        ``coordinate_reference_frame``. Null unless a position is known.
+    declination : float, optional
+        Declination in degrees, [-90, 90]. Interpreted in the catalog's
+        ``coordinate_reference_frame``. Null unless a position is known.
     catalog : MissionCatalog
         The catalog this target belongs to
     datasets : list[DataSet]
@@ -179,13 +190,37 @@ class Target(LCDBModel):
     The combination of catalog_id and name must be unique,
     ensuring no duplicate targets within a catalog.
 
+    ``right_ascension`` and ``declination`` are constrained at the database
+    level to be either both null or both present (no half-coordinates), and
+    when present to lie within valid celestial degrees -- RA in [0, 360) and
+    Dec in [-90, 90]. The range bounds also reject NaN and +/-Infinity.
+
     Indexing a target by parameter name -- ``target["effective_temperature"]``
     -- returns that parameter as an astropy quantity (see
     :meth:`__getitem__`).
     """
 
     __tablename__ = "target"
-    __table_args__ = (sa.UniqueConstraint("catalog_id", "name"),)
+    __table_args__ = (
+        sa.UniqueConstraint("catalog_id", "name"),
+        # ra and dec are co-present: both set or both NULL, never a
+        # half-coordinate. A CHECK is a per-row write-time test (no index, no
+        # read cost) -- spatial indexing is a separate, downstream concern.
+        sa.CheckConstraint(
+            "(right_ascension IS NULL) = (declination IS NULL)",
+            name="ck_target_radec_co_null",
+        ),
+        # When present: finite AND valid celestial degrees,
+        # RA in [0, 360) and Dec in [-90, 90]. The range bounds double as the
+        # finiteness guard -- PostgreSQL sorts NaN above Infinity, so NaN and
+        # +/-Infinity all fall outside the range and are rejected.
+        sa.CheckConstraint(
+            "right_ascension IS NULL OR ("
+            " right_ascension >= 0 AND right_ascension < 360"
+            " AND declination >= -90 AND declination <= 90)",
+            name="ck_target_radec_range",
+        ),
+    )
 
     id: orm.Mapped[int] = orm.mapped_column(sa.BigInteger, primary_key=True)
     catalog_id: orm.Mapped[int] = orm.mapped_column(
@@ -194,6 +229,8 @@ class Target(LCDBModel):
         )
     )
     name: orm.Mapped[int] = orm.mapped_column(sa.BigInteger)
+    right_ascension: orm.Mapped[float | None]
+    declination: orm.Mapped[float | None]
 
     # Relationships
     catalog: orm.Mapped["MissionCatalog"] = orm.relationship(

--- a/src/lightcurvedb/models/target.py
+++ b/src/lightcurvedb/models/target.py
@@ -5,8 +5,10 @@ from typing import TYPE_CHECKING
 
 import sqlalchemy as sa
 from sqlalchemy.ext import associationproxy as ap
+from sqlalchemy.ext.hybrid import hybrid_property
 from astropy import time
 from astropy import units as u
+from astropy.coordinates import SkyCoord
 from sqlalchemy import orm
 
 from lightcurvedb.core.base_model import (
@@ -113,8 +115,9 @@ class MissionCatalog(LCDBModel, NameAndDescriptionMixin, CreatedOnMixin):
         Detailed description of the catalog
     coordinate_reference_frame : str
         Reference frame the catalog's target coordinates
-        (``Target.right_ascension`` / ``declination``) are expressed in.
-        Defaults to ``"J2000"``.
+        (``Target.right_ascension`` / ``declination``) are expressed in,
+        as an astropy frame name (e.g. ``"ICRS"``, ``"FK5"``). Defaults to
+        ``"ICRS"`` and is consumed by :attr:`Target.coordinate`.
     host_mission : Mission
         Parent mission this catalog belongs to
     targets : list[Target]
@@ -128,7 +131,9 @@ class MissionCatalog(LCDBModel, NameAndDescriptionMixin, CreatedOnMixin):
     host_mission_id: orm.Mapped[uuid.UUID] = orm.mapped_column(
         sa.ForeignKey(Mission.id, ondelete="CASCADE")
     )
-    coordinate_reference_frame: orm.Mapped[str] = orm.mapped_column(default="J2000")
+    coordinate_reference_frame: orm.Mapped[str] = orm.mapped_column(
+        default="ICRS"
+    )
 
     # Relationships
     host_mission: orm.Mapped["Mission"] = orm.relationship(
@@ -184,6 +189,8 @@ class Target(LCDBModel):
         Astrophysical parameters measured for this target
     parameters_by_name : dict[str, AstroParameter]
         Read-only view of ``parameters`` keyed by parameter name
+    coordinate : astropy.coordinates.SkyCoord or None
+        The target's sky position as a SkyCoord (see :attr:`coordinate`).
 
     Notes
     -----
@@ -194,6 +201,11 @@ class Target(LCDBModel):
     level to be either both null or both present (no half-coordinates), and
     when present to lie within valid celestial degrees -- RA in [0, 360) and
     Dec in [-90, 90]. The range bounds also reject NaN and +/-Infinity.
+
+    :attr:`coordinate` is a hybrid attribute: on a loaded instance it returns
+    an :class:`astropy.coordinates.SkyCoord` (or ``None`` if the target has no
+    position); in a SQL expression it resolves to the
+    ``(right_ascension, declination)`` degree pair.
 
     Indexing a target by parameter name -- ``target["effective_temperature"]``
     -- returns that parameter as an astropy quantity (see
@@ -296,6 +308,53 @@ class Target(LCDBModel):
             viewonly=True,
         )
     )
+
+    @hybrid_property
+    def coordinate(self) -> SkyCoord | None:
+        """
+        The target's sky position as an astropy :class:`SkyCoord`.
+
+        Built from :attr:`right_ascension` / :attr:`declination` (degrees) in
+        the catalog's :attr:`MissionCatalog.coordinate_reference_frame`.
+        Returns ``None`` when the target has no recorded position; the
+        ``ck_target_radec_co_null`` constraint guarantees the two columns are
+        set together, so a partial coordinate never occurs.
+
+        Returns
+        -------
+        astropy.coordinates.SkyCoord or None
+            The position, or ``None`` if ra/dec are unset.
+
+        Notes
+        -----
+        Reading the frame touches the :attr:`catalog` relationship, which
+        lazy-loads it if not already present. Eager-load the catalog
+        (e.g. ``selectinload(Target.catalog)``) when building coordinates for
+        many targets to avoid per-row queries.
+
+        The reference frame must be an equatorial astropy frame (``icrs``,
+        ``fk5``, ...) since the stored values are ra/dec.
+        """
+        if self.right_ascension is None or self.declination is None:
+            return None
+        return SkyCoord(
+            ra=self.right_ascension * u.deg,
+            dec=self.declination * u.deg,
+            frame=self.catalog.coordinate_reference_frame.lower(),
+        )
+
+    @coordinate.expression
+    def coordinate(cls):
+        """
+        SQL form of :attr:`coordinate`: the ``(ra, dec)`` degree pair.
+
+        A SkyCoord has no SQL representation, so in a query
+        ``Target.coordinate`` resolves to a row of the two degree columns --
+        usable for equality and ``IN`` filters, e.g.
+        ``select(Target).where(Target.coordinate.in_([(ra, dec), ...]))``.
+        Spatial / cone search is intentionally left to downstream indexing.
+        """
+        return sa.tuple_(cls.right_ascension, cls.declination)
 
     def __repr__(self) -> str:
         return (

--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -4,9 +4,10 @@ import uuid
 
 import numpy as np
 import pytest
+from astropy.coordinates import SkyCoord
 from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
-from sqlalchemy import delete, exc, orm
+from sqlalchemy import delete, exc, orm, select
 
 from lightcurvedb.models import (
     Instrument,
@@ -827,3 +828,71 @@ class TestTargetCoordinates:
             v2_db.flush()  # constraints evaluated here; must not raise
         finally:
             v2_db.rollback()
+
+
+class TestTargetCoordinateProperty:
+    """The ``Target.coordinate`` hybrid: SkyCoord on instances, (ra, dec) in SQL.
+
+    On a loaded target the attribute builds an astropy SkyCoord from the ra/dec
+    columns in the catalog's reference frame; in a SQL expression it resolves
+    to the ``(right_ascension, declination)`` degree pair.
+    """
+
+    def test_returns_skycoord_with_default_frame(self, v2_db: orm.Session):
+        """A positioned target yields a SkyCoord in the default ICRS frame."""
+        catalog = _coord_catalog(v2_db)
+        assert catalog.coordinate_reference_frame == "ICRS"  # default applied
+        target = Target(
+            catalog=catalog, name=1, right_ascension=123.45, declination=-67.8
+        )
+        v2_db.add(target)
+        v2_db.commit()
+
+        coord = target.coordinate
+        assert isinstance(coord, SkyCoord)
+        assert coord.frame.name == "icrs"
+        assert coord.ra.deg == pytest.approx(123.45)
+        assert coord.dec.deg == pytest.approx(-67.8)
+
+    def test_returns_none_without_position(self, v2_db: orm.Session):
+        """A target with no ra/dec has no coordinate."""
+        catalog = _coord_catalog(v2_db)
+        target = Target(catalog=catalog, name=1)
+        v2_db.add(target)
+        v2_db.commit()
+
+        assert target.coordinate is None
+
+    def test_honors_catalog_frame(self, v2_db: orm.Session):
+        """The SkyCoord frame comes from the catalog's reference frame."""
+        catalog = _coord_catalog(v2_db, suffix="FK5")
+        catalog.coordinate_reference_frame = "FK5"  # equatorial; accepts ra/dec
+        v2_db.flush()
+        target = Target(
+            catalog=catalog, name=1, right_ascension=10.0, declination=20.0
+        )
+        v2_db.add(target)
+        v2_db.commit()
+
+        coord = target.coordinate
+        assert isinstance(coord, SkyCoord)
+        assert coord.frame.name == "fk5"
+
+    def test_usable_in_select_query(self, v2_db: orm.Session):
+        """The SQL expression filters on the (ra, dec) pair via IN."""
+        catalog = _coord_catalog(v2_db)
+        positioned = Target(
+            catalog=catalog, name=1, right_ascension=10.0, declination=20.0
+        )
+        other = Target(
+            catalog=catalog, name=2, right_ascension=30.0, declination=40.0
+        )
+        no_position = Target(catalog=catalog, name=3)
+        v2_db.add_all([positioned, other, no_position])
+        v2_db.commit()
+
+        found = v2_db.execute(
+            select(Target).where(Target.coordinate.in_([(10.0, 20.0)]))
+        ).scalars().all()
+
+        assert found == [positioned]

--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -4,6 +4,8 @@ import uuid
 
 import numpy as np
 import pytest
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
 from sqlalchemy import delete, exc, orm
 
 from lightcurvedb.models import (
@@ -15,6 +17,30 @@ from lightcurvedb.models import (
     Target,
     TargetSpecificTime,
 )
+
+
+def _coord_catalog(
+    session: orm.Session, suffix: str = "COORD"
+) -> MissionCatalog:
+    """Persist a mission + catalog for coordinate tests and return the catalog."""
+    mission = Mission(
+        id=uuid.uuid4(),
+        name=f"{suffix}_MISSION",
+        description="Coordinate test mission",
+        time_unit="day",
+        time_epoch=0.0,
+        time_epoch_scale="tdb",
+        time_epoch_format="jd",
+        time_format_name=f"{suffix}_fmt",  # unique per mission
+    )
+    catalog = MissionCatalog(
+        host_mission=mission,
+        name=f"{suffix}_CAT",
+        description="Coordinate catalog",
+    )
+    session.add_all([mission, catalog])
+    session.flush()
+    return catalog
 
 
 class TestTargetBasics:
@@ -679,3 +705,125 @@ class TestTargetQueries:
         assert len(targets_with_observations) == 1
         assert target_with_obs in targets_with_observations
         assert target_without_obs not in targets_with_observations
+
+
+class TestTargetCoordinates:
+    """Celestial-coordinate columns and their CHECK constraints.
+
+    ``right_ascension`` / ``declination`` must be co-present (both set or both
+    NULL) and, when set, finite and within valid celestial degrees -- RA in
+    [0, 360), Dec in [-90, 90]. Enforced at the database level by
+    ``ck_target_radec_co_null`` and ``ck_target_radec_range``.
+    """
+
+    @pytest.mark.parametrize(
+        "ra, dec",
+        [
+            (None, None),  # both absent -- the common case
+            (0.0, -90.0),  # inclusive lower boundaries
+            (359.999, 90.0),  # RA just below 360, Dec at upper boundary
+            (123.45, -67.8),  # interior
+            (0.0, 0.0),  # origin
+        ],
+    )
+    def test_valid_coordinates_accepted(self, v2_db: orm.Session, ra, dec):
+        """Co-present, in-range coordinates (and the all-NULL case) commit."""
+        catalog = _coord_catalog(v2_db)
+        target = Target(
+            catalog=catalog, name=1, right_ascension=ra, declination=dec
+        )
+        v2_db.add(target)
+        v2_db.commit()
+
+        assert target.id is not None
+        assert target.right_ascension == ra
+        assert target.declination == dec
+
+    @pytest.mark.parametrize(
+        "ra, dec",
+        [
+            (10.0, None),  # ra set, dec missing
+            (None, 10.0),  # dec set, ra missing
+        ],
+    )
+    def test_half_coordinate_rejected(self, v2_db: orm.Session, ra, dec):
+        """Only one of ra/dec set violates co-nullability."""
+        catalog = _coord_catalog(v2_db)
+        v2_db.add(
+            Target(
+                catalog=catalog, name=1, right_ascension=ra, declination=dec
+            )
+        )
+        with pytest.raises(exc.IntegrityError) as excinfo:
+            v2_db.commit()
+        v2_db.rollback()
+        assert "ck_target_radec_co_null" in str(excinfo.value)
+
+    @pytest.mark.parametrize(
+        "ra, dec",
+        [
+            (float("nan"), 0.0),  # NaN ra
+            (0.0, float("nan")),  # NaN dec
+            (float("inf"), 0.0),  # +Infinity ra
+            (float("-inf"), 0.0),  # -Infinity ra
+            (0.0, float("inf")),  # +Infinity dec
+            (-0.001, 0.0),  # ra below 0
+            (360.0, 0.0),  # ra == 360 (upper bound is exclusive)
+            (400.0, 0.0),  # ra above range
+            (0.0, 90.001),  # dec above range
+            (0.0, -90.001),  # dec below range
+        ],
+    )
+    def test_out_of_range_or_nonfinite_rejected(
+        self, v2_db: orm.Session, ra, dec
+    ):
+        """NaN, +/-Infinity, and out-of-range degrees violate the range check."""
+        catalog = _coord_catalog(v2_db)
+        v2_db.add(
+            Target(
+                catalog=catalog, name=1, right_ascension=ra, declination=dec
+            )
+        )
+        with pytest.raises(exc.IntegrityError) as excinfo:
+            v2_db.commit()
+        v2_db.rollback()
+        assert "ck_target_radec_range" in str(excinfo.value)
+
+    @settings(
+        suppress_health_check=[HealthCheck.function_scoped_fixture],
+        deadline=None,
+        max_examples=50,
+    )
+    @given(
+        ra=st.floats(
+            min_value=0,
+            max_value=360,
+            exclude_max=True,
+            allow_nan=False,
+            allow_infinity=False,
+        ),
+        dec=st.floats(
+            min_value=-90,
+            max_value=90,
+            allow_nan=False,
+            allow_infinity=False,
+        ),
+    )
+    def test_any_valid_celestial_degrees_accepted(
+        self, v2_db: orm.Session, ra, dec
+    ):
+        """Property: any in-range (ra, dec) pair satisfies the constraints.
+
+        Each example is rolled back, so the function-scoped session stays clean
+        and target names never collide across examples.
+        """
+        catalog = _coord_catalog(v2_db)
+        v2_db.add(
+            Target(
+                catalog=catalog, name=1, right_ascension=ra, declination=dec
+            )
+        )
+        try:
+            v2_db.flush()  # constraints evaluated here; must not raise
+        finally:
+            v2_db.rollback()

--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -4,6 +4,7 @@ import uuid
 
 import numpy as np
 import pytest
+from astropy import units as u
 from astropy.coordinates import SkyCoord
 from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
@@ -878,6 +879,39 @@ class TestTargetCoordinateProperty:
         assert isinstance(coord, SkyCoord)
         assert coord.frame.name == "fk5"
 
+    def test_includes_proper_motion_when_present(self, v2_db: orm.Session):
+        """A target with proper motion yields a SkyCoord with PM differentials."""
+        catalog = _coord_catalog(v2_db)
+        target = Target(
+            catalog=catalog,
+            name=1,
+            right_ascension=10.0,
+            declination=20.0,
+            pm_ra_cosdec=5.5,
+            pm_dec=-3.2,
+        )
+        v2_db.add(target)
+        v2_db.commit()
+
+        coord = target.coordinate
+        assert isinstance(coord, SkyCoord)
+        assert "s" in coord.data.differentials  # velocity present
+        assert coord.pm_ra_cosdec.to_value(u.mas / u.yr) == pytest.approx(5.5)
+        assert coord.pm_dec.to_value(u.mas / u.yr) == pytest.approx(-3.2)
+
+    def test_position_only_when_no_proper_motion(self, v2_db: orm.Session):
+        """Without proper motion the SkyCoord carries no velocity differentials."""
+        catalog = _coord_catalog(v2_db)
+        target = Target(
+            catalog=catalog, name=1, right_ascension=10.0, declination=20.0
+        )
+        v2_db.add(target)
+        v2_db.commit()
+
+        coord = target.coordinate
+        assert isinstance(coord, SkyCoord)
+        assert coord.data.differentials == {}
+
     def test_usable_in_select_query(self, v2_db: orm.Session):
         """The SQL expression filters on the (ra, dec) pair via IN."""
         catalog = _coord_catalog(v2_db)
@@ -896,3 +930,114 @@ class TestTargetCoordinateProperty:
         ).scalars().all()
 
         assert found == [positioned]
+
+
+class TestTargetProperMotion:
+    """Proper-motion columns and their CHECK constraints.
+
+    ``pm_ra_cosdec`` / ``pm_dec`` (mas/yr) must be co-present (both set or both
+    NULL), finite when set, and require a position. Enforced by
+    ``ck_target_pm_co_null``, ``ck_target_pm_finite`` and
+    ``ck_target_pm_requires_position``.
+    """
+
+    @pytest.mark.parametrize(
+        "pm_ra, pm_dec",
+        [
+            (None, None),  # no proper motion
+            (5.5, -3.2),  # finite pair
+            (0.0, 0.0),  # zero motion is still a measurement
+            (-1234.5, 6789.0),  # large but finite (high-PM star)
+        ],
+    )
+    def test_valid_proper_motion_accepted(
+        self, v2_db: orm.Session, pm_ra, pm_dec
+    ):
+        """Co-present, finite proper motion (with a position) commits."""
+        catalog = _coord_catalog(v2_db)
+        target = Target(
+            catalog=catalog,
+            name=1,
+            right_ascension=10.0,
+            declination=20.0,
+            pm_ra_cosdec=pm_ra,
+            pm_dec=pm_dec,
+        )
+        v2_db.add(target)
+        v2_db.commit()
+
+        assert target.id is not None
+        assert target.pm_ra_cosdec == pm_ra
+        assert target.pm_dec == pm_dec
+
+    @pytest.mark.parametrize(
+        "pm_ra, pm_dec",
+        [
+            (5.5, None),  # pm_ra set, pm_dec missing
+            (None, -3.2),  # pm_dec set, pm_ra missing
+        ],
+    )
+    def test_half_proper_motion_rejected(
+        self, v2_db: orm.Session, pm_ra, pm_dec
+    ):
+        """Only one proper-motion component set violates co-nullability."""
+        catalog = _coord_catalog(v2_db)
+        v2_db.add(
+            Target(
+                catalog=catalog,
+                name=1,
+                right_ascension=10.0,
+                declination=20.0,
+                pm_ra_cosdec=pm_ra,
+                pm_dec=pm_dec,
+            )
+        )
+        with pytest.raises(exc.IntegrityError) as excinfo:
+            v2_db.commit()
+        v2_db.rollback()
+        assert "ck_target_pm_co_null" in str(excinfo.value)
+
+    @pytest.mark.parametrize(
+        "pm_ra, pm_dec",
+        [
+            (float("nan"), 1.0),  # NaN pm_ra
+            (1.0, float("nan")),  # NaN pm_dec
+            (float("inf"), 1.0),  # +Infinity
+            (1.0, float("-inf")),  # -Infinity
+        ],
+    )
+    def test_nonfinite_proper_motion_rejected(
+        self, v2_db: orm.Session, pm_ra, pm_dec
+    ):
+        """NaN / +/-Infinity in either component violates the finiteness check."""
+        catalog = _coord_catalog(v2_db)
+        v2_db.add(
+            Target(
+                catalog=catalog,
+                name=1,
+                right_ascension=10.0,
+                declination=20.0,
+                pm_ra_cosdec=pm_ra,
+                pm_dec=pm_dec,
+            )
+        )
+        with pytest.raises(exc.IntegrityError) as excinfo:
+            v2_db.commit()
+        v2_db.rollback()
+        assert "ck_target_pm_finite" in str(excinfo.value)
+
+    def test_proper_motion_requires_position(self, v2_db: orm.Session):
+        """Proper motion without a position (ra/dec) is rejected."""
+        catalog = _coord_catalog(v2_db)
+        v2_db.add(
+            Target(
+                catalog=catalog,
+                name=1,
+                pm_ra_cosdec=5.5,
+                pm_dec=-3.2,
+            )
+        )
+        with pytest.raises(exc.IntegrityError) as excinfo:
+            v2_db.commit()
+        v2_db.rollback()
+        assert "ck_target_pm_requires_position" in str(excinfo.value)


### PR DESCRIPTION
> **WIP / draft.** Opening early for visibility; ready for review once marked non-draft.

Adds optional astrometry to `Target`, building on the merged astrophysical-parameters work. Three stacked commits:

### 1. Celestial coordinates + validity constraints (`ae544e0`)
- `right_ascension` / `declination` (nullable `double precision`, degrees) on `Target`; `coordinate_reference_frame` on `MissionCatalog` (default `"ICRS"`).
- Two DB-level `CHECK` constraints:
  - `ck_target_radec_co_null` — both set or both NULL (no half-coordinates).
  - `ck_target_radec_range` — RA ∈ [0, 360), Dec ∈ [-90, 90]; the range bounds also reject `NaN`/`±Infinity`.
- Spatial indexing (Q3C, etc.) is intentionally left to downstream pipelines — a `CHECK` is a per-row write-time test, orthogonal to indexing.

### 2. `Target.coordinate` SkyCoord hybrid (`9812904`)
- `@hybrid_property`: on an instance returns an `astropy.coordinates.SkyCoord` (or `None`); in a SQL expression resolves to the `(ra, dec)` degree pair (usable for equality / `IN` filters). A SkyCoord has no SQL form, so spatial/cone search stays downstream.

### 3. Optional proper motion (`14d965b`)
- `pm_ra_cosdec` / `pm_dec` (nullable `double precision`, mas/yr). `pm_ra_cosdec` is the cos(dec)-corrected RA rate (Gaia/TIC + astropy convention → maps to SkyCoord with no conversion).
- Three `CHECK` constraints: `ck_target_pm_co_null`, `ck_target_pm_finite` (rejects `NaN`/`±Infinity`; PM has no bounded range so finiteness is explicit), `ck_target_pm_requires_position`.
- `Target.coordinate` folds PM into the SkyCoord (velocity differentials) when present.

### Testing
- `TestTargetCoordinates`, `TestTargetCoordinateProperty`, `TestTargetProperMotion` in `tests/test_target.py`.
- `tests/test_target.py`: **51 passed** (nox, py3.11). Constraint semantics and astropy round-trips verified against the live Postgres 14.

### Notes for reviewers
- Base is `staging` (per the project flow); diff is the astrometry work only (3 files).
- Out of scope / possible follow-ups: parallax + radial velocity for full 6D SkyCoord; an obstime/epoch for proper-motion propagation; the Q3C spatial index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)